### PR TITLE
Add potentially missing include, add check and use unique_ptr when avail

### DIFF
--- a/lib/IlmCtl/CtlInterpreter.cpp
+++ b/lib/IlmCtl/CtlInterpreter.cpp
@@ -65,6 +65,7 @@
 #include <algorithm>
 #include <cassert>
 #include <string.h>
+#include <memory>
 
 #ifdef WIN32
     #include <io.h>
@@ -267,7 +268,11 @@ void Interpreter::_loadModule(const std::string &moduleName,
     // set up the source code string for parsing.
     // 
 
+#if __cplusplus >= 201103L
+    std::unique_ptr<istream> input;
+#else
     std::auto_ptr<istream> input;
+#endif
         
     if (!moduleSource.empty())
     {


### PR DESCRIPTION
right now the c preprocessor check for c++11 unique_ptr requires 201103, although it was available prior to that version, seems like the safest check to use for now...
