### PR TITLE
fix potential crash accessing de-allocated temporary memory

### DIFF
--- a/ctlrender/exr_file.cc
+++ b/ctlrender/exr_file.cc
@@ -151,8 +151,8 @@ void exr_write32(const char *name, float scale, const ctl::dpx::fb<float> &pixel
     float height = pixels.height();
     float const *pixelPtr = pixels.ptr();
     
+	ctl::dpx::fb<float> scaled_pixels;
     if (scale != 0.0 && scale != 1.0) {
-        ctl::dpx::fb<float> scaled_pixels;
         scaled_pixels.init(pixels.height(), pixels.width(), pixels.depth());
         scaled_pixels.alpha(1.0);
         


### PR DESCRIPTION
Not sure if anyone uses the scale feature, but there's a potential crash accessing out-of-scope temporary memory when writing a scaled 32-bit EXR file I noticed when working on my image engine for my little CTL compiler.
