### PR TITLE
aces_write link without Aces Container

### DIFF
--- a/ctlrender/aces_file.cc
+++ b/ctlrender/aces_file.cc
@@ -173,7 +173,7 @@ void aces_write(const char *name, float scale,
 
 void aces_write(const char *name, float scale,
                 uint32_t width, uint32_t height, uint32_t channels,
-                const void *pixels,
+                const float *pixels,
                 format_t *format)
 {
 	std::cerr << "AcesContainer library not found" << std::endl;


### PR DESCRIPTION
Changes input parameter pixel of Aces_Write from void\* to float\* so ctlrender can link without Aces Container.
