### PR TITLE
Multi-thrading crash fixes

### DIFF
--- a/lib/IlmCtlSimd/CtlSimdXContext.cpp
+++ b/lib/IlmCtlSimd/CtlSimdXContext.cpp
@@ -183,13 +183,6 @@ SimdStack::ownerFpRelative (int offset) const
     return _regPointers[i].owner ? TAKE_OWNERSHIP : REFERENCE_ONLY;
 }
 
-
-namespace {
-
-const std::string unknown = "unkown";
-
-} // namespace
-
 SimdXContext::SimdXContext (SimdInterpreter &interpreter):
     _interpreter (interpreter),
     _stack (1000),
@@ -200,7 +193,7 @@ SimdXContext::SimdXContext (SimdInterpreter &interpreter):
     _abortCount (0),
     _maxInstCount (0),
     _instCount (0),
-    _fileName (&unknown)
+    _fileName ("unknown")
 {
     (*_returnMask)[0] = false;
 }

--- a/lib/IlmCtlSimd/CtlSimdXContext.h
+++ b/lib/IlmCtlSimd/CtlSimdXContext.h
@@ -138,8 +138,8 @@ class SimdXContext
     int			lineNumber () const		{return _lineNumber;}
     void		setLineNumber (int ln)   	{_lineNumber = ln;}
     
-    const std::string & fileName () const		{return *_fileName;}
-    void		setFileName (const std::string &fn) {_fileName = &fn;}
+    const std::string & fileName () const		{return _fileName;}
+    void		setFileName (const std::string &fn) {_fileName = fn;}
 
     SimdModule*		module()			{return _module;}
     void		setModule(SimdModule* m)	{_module = m;}
@@ -162,7 +162,7 @@ class SimdXContext
     unsigned long	_abortCount;
     unsigned long	_maxInstCount;
     unsigned long	_instCount;
-    const std::string *	_fileName;
+    std::string		_fileName;
 };
 
 


### PR DESCRIPTION
As per the checkin comment:

SimdXContext::_fileName was a reference to a static std::string.  Two threads,
which each have their own SimdXContext, could simultaneously try to assign a
new value to _fileName, meaning they would simultaneously try to assign a new
value to the same static string.  In this case the assignment operation in each
thread would attempt to free the storage for the old value and you would get
the "double free" error.
