### PR TITLE
Master fixes for msvc10

### DIFF
--- a/lib/IlmCtl/CtlExc.cpp
+++ b/lib/IlmCtl/CtlExc.cpp
@@ -55,7 +55,9 @@
 #include <CtlExc.h>
 #include <stdarg.h>
 #include <stdio.h>
+#ifndef _MSC_VER
 #include <alloca.h>
+#endif
 #include <string.h>
 
 namespace Ctl {
@@ -70,7 +72,11 @@ void CtlExc::_explain(const char *text, va_list _ap) {
 		operator=("no explanation given.");
 	}
 	while(1) {
+#ifdef _MSC_VER
+		ap = _ap;
+#else
 		va_copy(ap, _ap);
+#endif
 		ptr=(char *)alloca(length);
 		memset(ptr, 0, length);
 		need_len=vsnprintf(ptr, length, text, ap);

--- a/lib/IlmCtl/CtlExc.h
+++ b/lib/IlmCtl/CtlExc.h
@@ -76,11 +76,13 @@ class CtlExc : public Iex::BaseExc {
 		CtlExc(std::stringstream &text) throw(): Iex::BaseExc(text) {};
 };
 
+
+
 #define CTL_DEFINE_EXC(name, base)                              \
     class name : public base                                    \
     {                                                           \
       public:                                                   \
-        name (const char* text=0, ...) throw() {                \
+        name (const char* text=0, ...) throw(): base (text) {   \
             va_list ap;                                         \
             va_start(ap, text);                                 \
             _explain(text, ap);                                 \

--- a/lib/IlmCtl/CtlInterpreter.cpp
+++ b/lib/IlmCtl/CtlInterpreter.cpp
@@ -82,6 +82,14 @@
     #include <unistd.h>
 #endif
 
+#if _MSC_VER
+#define snprintf _snprintf
+#include <time.h>
+#define rand_func rand
+#else
+#define rand_func lrand48
+#endif
+
 using namespace std;
 using namespace Iex;
 using namespace IlmThread;
@@ -414,7 +422,7 @@ void Interpreter::loadFile(const std::string &fileName,
 		// This might have unintended consequences...
 		memset(random, 0, sizeof(random));
 		snprintf(random, sizeof(random)-1, "module.%08x",
-		         (unsigned int)(time(NULL)+lrand48()));
+		         (unsigned int)(time(NULL)+rand_func()));
 		moduleName=random;
 	} else {
 		moduleName=_moduleName;

--- a/lib/IlmCtl/CtlStdType.cpp
+++ b/lib/IlmCtl/CtlStdType.cpp
@@ -55,6 +55,7 @@
 #include <CtlStdType.h>
 #include <cassert>
 #include <CtlErrors.h>
+#include <CtlSyntaxTree.h>
 #include <half.h>
 #include <CtlExc.h>
 #include <string.h>

--- a/lib/IlmCtl/CtlTypeStorage.cpp
+++ b/lib/IlmCtl/CtlTypeStorage.cpp
@@ -64,10 +64,12 @@
 #include <half.h>
 #include <CtlExc.h>
 #include <string.h>
-#include <alloca.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#ifndef _MSC_VER
+#include <alloca.h>
+#endif
 
 using namespace std;
 
@@ -219,7 +221,11 @@ void _convert(void *out, const void *in, CDataType_e out_type,
 				case HalfTypeEnum:
 				case FloatTypeEnum:
 					intermediate=FloatTypeEnum;
+#ifdef _MSC_VER
+					int_f=strtod(str, NULL);
+#else
 					int_f=strtof(str, NULL);
+#endif
 					break;
 
 				default:


### PR DESCRIPTION
Some fixes to build CTL libs (IlmCtl, IlmCtlMath, IlmCtlSimd, IlmImfCtl) on Windows 7 64 bits with msvc 10.
These commits are intended to be merged in master branch.

I also made 2 modifications that I didn't include in this pull request because they concern nukeNode branch: 
- [an msvc fix](https://github.com/mfe/CTL/commit/804ea0b505a6213ceaa7ae34b0961e2f072346a9)
- [a patch](https://github.com/mfe/CTL/commit/9165d891bc6ceb7240dd1856e9fb54ce66a6f344) which is a temporary workaround so that the node can be used on Windows. It'll need a proper correction.

Please note that the modifications I made in master also need to be merged in nukeNode branch so that the plugin could be built.
