### PR TITLE
Fix code source mode

### DIFF
--- a/lib/IlmCtl/CtlInterpreter.cpp
+++ b/lib/IlmCtl/CtlInterpreter.cpp
@@ -249,7 +249,7 @@ Interpreter::findModule (const string& moduleName)
             }
             
             THROW (ArgExc, "Cannot find CTL module \"" << moduleName << "\".");
-            return ""; 
+            return ""; // return to prevent a warning with some compilers.
         }
         
 
@@ -269,7 +269,7 @@ Interpreter::findModule (const string& moduleName)
     }
 
     THROW (ArgExc, "Cannot find CTL module \"" << moduleName << "\".");
-    return "";
+    return ""; // return to prevent a warning with some compilers.
 }
 
 void
@@ -435,7 +435,12 @@ Interpreter::loadModuleRecursive (const string &moduleName, const string &fileNa
 	return;
     }
     
-    string realFileName = fileName.empty() ? findModule (moduleName) : fileName;
+	string realFileName;
+	if(fileName.empty() && !moduleName.empty())
+		realFileName = findModule (moduleName);
+	else
+		realFileName = fileName;
+
 
 	_loadModule(moduleName, realFileName, moduleSource);
 }


### PR DESCRIPTION
[TuttleCTL](http://www.tuttleofx.org/user-documentation/plugins) can be used by specifying directly source code.
With CTL 1.5, this get me a "Cannot find CTL module" error.

Indeed, even when filename and moduleName were empty, a findModule was done and throws an exception preventing moduleSource to be use instead.
