### PR TITLE
dpx_file: Throw exception on invalid file read

### DIFF
--- a/ctlrender/dpx_file.cc
+++ b/ctlrender/dpx_file.cc
@@ -65,6 +65,12 @@ bool dpx_read(const char *name, float scale, ctl::dpx::fb<float> *pixels,
 
 	file.open(name);
 
+	if (file.fail())
+	{
+		THROW(Iex::ArgExc, "dpx_read() cannot open input file " << std::string(name));
+		return 0;
+	}
+
 	if(!ctl::dpx::check_magic(&file)) {
 		return 0;
 	}


### PR DESCRIPTION
If dpx_read() fails to open a file for any reason, report the failure via a exception an return 0.

Fixes #122