### PR TITLE
Issues/0134 shared and static builds

### DIFF
--- a/.github/workflows/docker_linuxes.yml
+++ b/.github/workflows/docker_linuxes.yml
@@ -12,6 +12,30 @@ on:
 
 jobs:
 
+  Dockerfile-repo-root:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build --no-cache --rm -f ./Dockerfile -t ctl:latest .
+
+    - name: Run unit tests (ctest) within the Docker image
+      run: docker run ctl:latest sh -c "cd ./build && ctest"
+
+  Dockerfile_openexr3-repo-root:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build the Docker image
+        run: docker build --no-cache --rm -f ./Dockerfile_openexr3 -t ctl:latest .
+
+      - name: Run unit tests (ctest) within the Docker image
+        run: docker run ctl:latest sh -c "cd ./build && ctest"
+
   ubuntu-18-04:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_linuxes.yml
+++ b/.github/workflows/docker_linuxes.yml
@@ -48,14 +48,14 @@ jobs:
     - name: Run unit tests (ctest) within the Docker image
       run: docker run ctl:latest sh -c "cd ./build && ctest"
 
-  ubuntu-22-10:
+  ubuntu-23-10:
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
     - name: Build the Docker image
-      run: docker build --no-cache --rm -f ./docker/Dockerfile_ubuntu_22.10 -t ctl:latest .
+      run: docker build --no-cache --rm -f ./docker/Dockerfile_ubuntu_23.10 -t ctl:latest .
 
     - name: Run unit tests (ctest) within the Docker image
       run: docker run ctl:latest sh -c "cd ./build && ctest"

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -227,26 +227,3 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -V --output-on-failure
-
-  test-ctl-brew:
-
-    runs-on: macos-latest
-
-    steps:
-
-    - name: install ctl 
-      run:  brew install --HEAD ctl 
-
-    - uses: actions/checkout@v3
-
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
-    
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -V --output-on-failure
-

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -16,6 +16,29 @@ env:
 
 jobs:
 
+  build-brew:
+
+    runs-on: macos-latest
+
+    steps:
+
+    - name: install libtiff 
+      run:  brew install libtiff 
+
+    - name: install openexr 
+      run:  brew install openexr 
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
   build-openexr2:
 
     runs-on: macos-latest

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
 
-  build-brew:
+  build-openexr-brew:
 
     runs-on: macos-latest
 
@@ -199,7 +199,7 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -V --output-on-failure 
 
-  test-brew:
+  test-openexr-brew:
 
     runs-on: macos-latest
 
@@ -227,3 +227,26 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -V --output-on-failure
+
+  test-ctl-brew:
+
+    runs-on: macos-latest
+
+    steps:
+
+    - name: install ctl 
+      run:  brew install --HEAD ctl 
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+    
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -V --output-on-failure
+

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -112,6 +112,84 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+  
+  build-openexr3-static:
+    runs-on: macos-latest
+
+    steps:
+
+    - name: install dependencies - imath
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/Imath.git &&
+        cd Imath &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=OFF .. &&
+        make &&
+        make install
+
+    - name: install dependencies - openexr v3.1
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+        cd openexr &&
+        git checkout RB-3.1 &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=OFF .. &&
+        make &&
+        make install
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_SHARED_LIBS=OFF
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+  build-openexr3-shared:
+    runs-on: macos-latest
+
+    steps:
+
+      - name: install dependencies - imath
+        run:  |
+          cd ..
+          git clone https://github.com/AcademySoftwareFoundation/Imath.git &&
+          cd Imath &&
+          mkdir build &&
+          cd build &&
+          cmake -DBUILD_SHARED_LIBS=ON .. &&
+          make &&
+          make install
+  
+      - name: install dependencies - openexr v3.1
+        run:  |
+          cd ..
+          git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+          cd openexr &&
+          git checkout RB-3.1 &&
+          mkdir build &&
+          cd build &&
+          cmake -DBUILD_SHARED_LIBS=ON .. &&
+          make &&
+          make install
+  
+      - uses: actions/checkout@v3
+  
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_SHARED_LIBS=ON
+  
+      - name: Build
+        # Build your program with the given configuration
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}       
 
   test-openexr2:
 

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -191,6 +191,35 @@ jobs:
         # Build your program with the given configuration
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}       
 
+  test-openexr-brew:
+
+    runs-on: macos-latest
+
+    steps:
+
+    - name: install libtiff 
+      run:  brew install libtiff 
+
+    - name: install openexr 
+      run:  brew install openexr 
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -V --output-on-failure
+      
   test-openexr2:
 
     runs-on: macos-latest
@@ -277,24 +306,40 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -V --output-on-failure 
 
-  test-openexr-brew:
-
+  test-openexr3-static:
     runs-on: macos-latest
 
     steps:
 
-    - name: install libtiff 
-      run:  brew install libtiff 
+    - name: install dependencies - imath
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/Imath.git &&
+        cd Imath &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=OFF .. &&
+        make &&
+        make install
 
-    - name: install openexr 
-      run:  brew install openexr 
+    - name: install dependencies - openexr v3.1
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+        cd openexr &&
+        git checkout RB-3.1 &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=OFF .. &&
+        make &&
+        make install
 
     - uses: actions/checkout@v3
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_SHARED_LIBS=OFF
 
     - name: Build
       # Build your program with the given configuration
@@ -304,4 +349,49 @@ jobs:
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -V --output-on-failure
+      run: ctest -V --output-on-failure 
+
+  test-openexr3-shared:
+    runs-on: macos-latest
+
+    steps:
+
+    - name: install dependencies - imath
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/Imath.git &&
+        cd Imath &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=ON .. &&
+        make &&
+        make install
+
+    - name: install dependencies - openexr v3.1
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+        cd openexr &&
+        git checkout RB-3.1 &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=ON .. &&
+        make &&
+        make install
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_SHARED_LIBS=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -V --output-on-failure 

--- a/.github/workflows/mac_release.yml
+++ b/.github/workflows/mac_release.yml
@@ -199,3 +199,31 @@ jobs:
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ctest -V --output-on-failure 
 
+  test-brew:
+
+    runs-on: macos-latest
+
+    steps:
+
+    - name: install libtiff 
+      run:  brew install libtiff 
+
+    - name: install openexr 
+      run:  brew install openexr 
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -V --output-on-failure

--- a/.github/workflows/ubuntu_release.yml
+++ b/.github/workflows/ubuntu_release.yml
@@ -138,6 +138,61 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       run: ctest -V --output-on-failure
+  
+  test-openexr3-static:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: remove ilmbase
+      run: sudo apt-get --purge remove libilmbase-dev -y
+
+    - name: remove openexr
+      run: sudo apt-get --purge remove libopenexr-dev -y
+
+    - name: install dependencies - imath
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/Imath.git &&
+        cd Imath &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=OFF .. &&
+        make &&
+        sudo make install
+
+    - name: install dependencies - zlib
+      run: sudo apt-get -y install zlib1g-dev
+
+    - name: install dependencies - openexr v3.1
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+        cd openexr &&
+        git checkout RB-3.1 &&
+        mkdir build &&
+        cd build &&
+        cmake ..  -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DOPENEXR_BUILD_TOOLS=OFF -DOPENEXR_INSTALL_EXAMPLES=OFF &&
+        make  &&
+        sudo make install
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DBUILD_SHARED_LIBS=OFF
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -V --output-on-failure
 
   valgrind-openexr2:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.

--- a/.github/workflows/ubuntu_release.yml
+++ b/.github/workflows/ubuntu_release.yml
@@ -194,6 +194,61 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ctest -V --output-on-failure
 
+  test-openexr3-shared:
+    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
+    # You can convert this to a matrix build if you need cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: remove ilmbase
+      run: sudo apt-get --purge remove libilmbase-dev -y
+
+    - name: remove openexr
+      run: sudo apt-get --purge remove libopenexr-dev -y
+
+    - name: install dependencies - imath
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/Imath.git &&
+        cd Imath &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=ON .. &&
+        make &&
+        sudo make install
+
+    - name: install dependencies - zlib
+      run: sudo apt-get -y install zlib1g-dev
+
+    - name: install dependencies - openexr v3.1
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+        cd openexr &&
+        git checkout RB-3.1 &&
+        mkdir build &&
+        cd build &&
+        cmake ..  -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF -DOPENEXR_BUILD_TOOLS=OFF -DOPENEXR_INSTALL_EXAMPLES=OFF &&
+        make  &&
+        sudo make install
+
+    - uses: actions/checkout@v3
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DBUILD_SHARED_LIBS=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      run: ctest -V --output-on-failure
+
   valgrind-openexr2:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ add_definitions( -DPACKAGE="${PROJECT_NAME}" -DVERSION="${PROJECT_VERSION}" )
 
 option(CTL_BUILD_TESTS "Build the unit tests" ON)
 option(CTL_BUILD_TOOLS "Build the utility commands (ctlrender, etc)" ON)
+option(BUILD_SHARED_LIBS "Build all libraries as shared" OFF )
 
 set(CMAKE_CXX_FLAGS_ASAN
   "-fsanitize=address -fno-optimize-sibling-calls -fsanitize-address-use-after-scope -fno-omit-frame-pointer -g -O1"
@@ -20,12 +21,27 @@ set(CMAKE_CXX_FLAGS_ASAN
   FORCE)
 
 if( NOT DEFINED CMAKE_BUILD_TYPE )
+  MESSAGE( STATUS "To use Release mode, use \"cmake .. -DCMAKE_BUILD_TYPE=Release\"" )
   MESSAGE( STATUS "To use AddressSanitizer, use \"cmake .. -DCMAKE_BUILD_TYPE=asan\"" )
+elseif( CMAKE_BUILD_TYPE STREQUAL "Release" )
+  MESSAGE( STATUS "Using Release mode - CMAKE_BUILD_TYPE : \"${CMAKE_BUILD_TYPE}\"")
 elseif( CMAKE_BUILD_TYPE STREQUAL "asan" )
   MESSAGE( STATUS "Using AddressSanitizer - CMAKE_BUILD_TYPE : \"${CMAKE_BUILD_TYPE}\"")
 else()
   MESSAGE( STATUS "CMAKE_BUILD_TYPE : \"${CMAKE_BUILD_TYPE}\"")
+  MESSAGE( STATUS "To use Release mode, use \"cmake .. -DCMAKE_BUILD_TYPE=Release\"" )
   MESSAGE( STATUS "To use AddressSanitizer, use \"cmake .. -DCMAKE_BUILD_TYPE=asan\"" )
+endif()
+
+# Set a default build type if none was specified
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+      STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+    "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
 find_package(OpenEXR 3 CONFIG QUIET)

--- a/docker/Dockerfile_ubuntu_23.10
+++ b/docker/Dockerfile_ubuntu_23.10
@@ -1,4 +1,4 @@
-FROM ubuntu:22.10
+FROM ubuntu:23.10
 
 RUN apt-get update
 


### PR DESCRIPTION
- switch CI workflow from Ubuntu 22.10 to 23.10 because Ubuntu 22.10 is out of support window
- add the repo's root dockers to the docker CI workflow
- add option for shared libraries
- set default build type to Release
- add mac release workflows that use brew to install dependencies
- add static and shared builds with openexr 3.1 to Ubuntu Release and MacOS Release CI workflows