### PR TITLE
Issues/0140 install from brew using brew install --head ctl

### DIFF
--- a/.github/workflows/docker_linuxes.yml
+++ b/.github/workflows/docker_linuxes.yml
@@ -72,6 +72,18 @@ jobs:
     - name: Run unit tests (ctest) within the Docker image
       run: docker run ctl:latest sh -c "cd ./build && ctest"
 
+  ubuntu-22-04-brew:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build --no-cache --rm -f ./docker/Dockerfile_ubuntu_22.04_brew -t ctl:latest .
+
+    - name: Run ctlrender within the Docker image
+      run: docker run ctl:latest sh -c "RUN ctlrender -ctl /usr/src/aces-dev/transforms/ctl/utilities/ACESutil.Unity.ctl /usr/src/aces-dev/images/ACES/SonyF35.StillLife.exr /tmp/testout.exr"
+
   ubuntu-23-10:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/docker_linuxes.yml
+++ b/.github/workflows/docker_linuxes.yml
@@ -82,7 +82,7 @@ jobs:
       run: docker build --no-cache --rm -f ./docker/Dockerfile_ubuntu_22.04_brew -t ctl:latest .
 
     - name: Run ctlrender within the Docker image
-      run: docker run ctl:latest sh -c "RUN ctlrender -ctl /usr/src/aces-dev/transforms/ctl/utilities/ACESutil.Unity.ctl /usr/src/aces-dev/images/ACES/SonyF35.StillLife.exr /tmp/testout.exr"
+      run: docker run ctl:latest sh -c "ctlrender -ctl /usr/src/aces-dev/transforms/ctl/utilities/ACESutil.Unity.ctl /usr/src/aces-dev/images/ACES/SonyF35.StillLife.exr /tmp/testout.exr"
 
   ubuntu-23-10:
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ can be downloaded from https://github.com/ampas/aces_container
     
         Homebrew will install all dependancies (cmake, ilmbase, opener, aces_container, libtiff) automatically by default.  No need to install each manually.
     
-            $ brew install ctl
+            $ brew install --head ctl
 
 
 * Redhat, Ubuntu

--- a/docker/Dockerfile_ubuntu_22.04_brew
+++ b/docker/Dockerfile_ubuntu_22.04_brew
@@ -1,0 +1,37 @@
+FROM ubuntu:22.04
+
+RUN apt-get update
+
+# disable interactive install 
+ENV DEBIAN_FRONTEND noninteractive
+
+# install tools
+RUN apt-get -y install curl
+RUN apt-get -y install git
+RUN apt-get -y install build-essential
+
+# install brew
+RUN NONINTERACTIVE=1 bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+RUN (echo; echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"') >> /root/.bashrc
+RUN eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+
+# add brew to PATH environment variable
+ENV PATH="/home/linuxbrew/.linuxbrew/bin:${PATH}"
+
+# install CTL using brew 
+RUN brew install --head ctl
+
+# download AMPAS ACES CTL reference code
+WORKDIR /usr/src/
+RUN git clone https://github.com/ampas/aces-dev.git
+
+# download AMPAS ACES reference images
+WORKDIR /usr/src/aces-dev/images/ACES
+RUN curl -L -o SonyF35.StillLife.exr https://www.dropbox.com/sh/9xcfbespknayuft/AAA04zUZyBYeHRHLaFry2XfDa/ACES/SonyF35.StillLife.exr
+
+# run ctlrender to test
+#RUN ctlrender -ctl /usr/src/aces-dev/transforms/ctl/utilities/ACESutil.Unity.ctl /usr/src/aces-dev/images/ACES/SonyF35.StillLife.exr /tmp/testout.exr
+
+# finalize docker environment
+WORKDIR /home
+


### PR DESCRIPTION
- Update readme with instructions to install ctl using brew from master source branch using
`brew install --head ctl`
- Add docker to github workflow that tests installing ctl with `brew install --head ctl`