### PR TITLE
Issues/0146 strict aliasing violations

### DIFF
--- a/.github/workflows/docker_linuxes.yml
+++ b/.github/workflows/docker_linuxes.yml
@@ -93,9 +93,8 @@ jobs:
     - name: Build the Docker image
       run: docker build --no-cache --rm -f ./docker/Dockerfile_ubuntu_22.04_LTO -t ctl:latest .
 
-    - name: Run ctlrender within the Docker image
-      run: docker run ctl:latest sh -c "ctlrender -ctl /usr/src/aces-dev/transforms/ctl/utilities/ACESutil.Unity.ctl /usr/src/aces-dev/images/ACES/SonyF35.StillLife.exr /tmp/testout.exr"
-  
+    - name: Run unit tests (ctest) within the Docker image
+      run: docker run ctl:latest sh -c "cd ./build && ctest"
 
   ubuntu-23-10:
 

--- a/.github/workflows/docker_linuxes.yml
+++ b/.github/workflows/docker_linuxes.yml
@@ -84,6 +84,19 @@ jobs:
     - name: Run ctlrender within the Docker image
       run: docker run ctl:latest sh -c "ctlrender -ctl /usr/src/aces-dev/transforms/ctl/utilities/ACESutil.Unity.ctl /usr/src/aces-dev/images/ACES/SonyF35.StillLife.exr /tmp/testout.exr"
 
+  ubuntu-22-04-LTO:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build --no-cache --rm -f ./docker/Dockerfile_ubuntu_22.04_LTO -t ctl:latest .
+
+    - name: Run ctlrender within the Docker image
+      run: docker run ctl:latest sh -c "ctlrender -ctl /usr/src/aces-dev/transforms/ctl/utilities/ACESutil.Unity.ctl /usr/src/aces-dev/images/ACES/SonyF35.StillLife.exr /tmp/testout.exr"
+  
+
   ubuntu-23-10:
 
     runs-on: ubuntu-latest

--- a/.github/workflows/windows_vcpkg_debug.yml
+++ b/.github/workflows/windows_vcpkg_debug.yml
@@ -30,8 +30,11 @@ jobs:
     - name: install dependencies - openexr
       run:  vcpkg install openexr 
 
-    - name: install dependencies - tiff
-      run:  vcpkg install tiff 
+    # disabling tiff due to security issue
+    # https://github.com/microsoft/vcpkg/issues/37871
+    # https://github.com/microsoft/vcpkg/issues/37839
+    #  - name: install dependencies - tiff
+    #  run:  vcpkg install tiff 
 
     - name: check vcpkg install status
       run: vcpkg list
@@ -66,8 +69,11 @@ jobs:
     - name: install dependencies - openexr
       run:  vcpkg install openexr 
 
-    - name: install dependencies - tiff
-      run:  vcpkg install tiff 
+    # disabling tiff due to security issue
+    # https://github.com/microsoft/vcpkg/issues/37871
+    # https://github.com/microsoft/vcpkg/issues/37839
+#    - name: install dependencies - tiff
+ #     run:  vcpkg install tiff 
 
     - name: check vcpkg install status
       run: vcpkg list

--- a/.github/workflows/windows_vcpkg_release.yml
+++ b/.github/workflows/windows_vcpkg_release.yml
@@ -30,8 +30,11 @@ jobs:
     - name: install dependencies - openexr
       run:  vcpkg install openexr:x64-windows
 
-    - name: install dependencies - tiff
-      run:  vcpkg install tiff:x64-windows
+    # disabling tiff due to security issue
+    # https://github.com/microsoft/vcpkg/issues/37871
+    # https://github.com/microsoft/vcpkg/issues/37839
+    #- name: install dependencies - tiff
+    #  run:  vcpkg install tiff:x64-windows
 
     - name: check vcpkg install status
       run: vcpkg list
@@ -66,8 +69,11 @@ jobs:
     - name: install dependencies - openexr
       run:  vcpkg install openexr:x64-windows
 
-    - name: install dependencies - tiff
-      run:  vcpkg install tiff:x64-windows
+    # disabling tiff due to security issue
+    # https://github.com/microsoft/vcpkg/issues/37871
+    # https://github.com/microsoft/vcpkg/issues/37839
+    #- name: install dependencies - tiff
+    #  run:  vcpkg install tiff:x64-windows
 
     - name: check vcpkg install status
       run: vcpkg list

--- a/docker/Dockerfile_ubuntu_22.04_LTO
+++ b/docker/Dockerfile_ubuntu_22.04_LTO
@@ -17,13 +17,8 @@ RUN apt-get -y install libtiff-dev
 WORKDIR /usr/src/CTL
 COPY . .
 WORKDIR /usr/src/CTL/build
-RUN rm -R *
+RUN rm -R * || true
 RUN cmake .. -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE -DCMAKE_VERBOSE_MAKEFILE=on -DCMAKE_CXX_FLAGS="-Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
-#RUN cmake .. -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing
-#RUN cmake ..
-#RUN make CXXFLAGS="-flto=4 -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
-#RUN make CXXFLAGS="-flto=4 -fno-fat-lto-objects"
-#RUN make CXXFLAGS="-Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
 RUN make 
 RUN make install
 

--- a/docker/Dockerfile_ubuntu_22.04_LTO
+++ b/docker/Dockerfile_ubuntu_22.04_LTO
@@ -1,0 +1,32 @@
+FROM ubuntu:22.04
+
+RUN apt-get update
+
+# disable interactive install 
+ENV DEBIAN_FRONTEND noninteractive
+
+# install developement tools
+RUN apt-get -y install cmake
+RUN apt-get -y install g++
+
+# install CTL dependencies
+RUN apt-get -y install libopenexr-dev
+RUN apt-get -y install libtiff-dev
+
+# build CTL
+WORKDIR /usr/src/CTL
+COPY . .
+WORKDIR /usr/src/CTL/build
+RUN rm -R *
+RUN cmake .. -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE -DCMAKE_VERBOSE_MAKEFILE=on -DCMAKE_CXX_FLAGS="-Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
+#RUN cmake .. -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing
+#RUN cmake ..
+#RUN make CXXFLAGS="-flto=4 -Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
+#RUN make CXXFLAGS="-flto=4 -fno-fat-lto-objects"
+#RUN make CXXFLAGS="-Werror=odr -Werror=lto-type-mismatch -Werror=strict-aliasing"
+RUN make 
+RUN make install
+
+# finalize docker environment
+WORKDIR /usr/src/CTL
+

--- a/lib/IlmCtlSimd/halfExpLog.h
+++ b/lib/IlmCtlSimd/halfExpLog.h
@@ -3,6 +3,7 @@
 // Do not edit.
 //
 
+#include <string.h>
 
 extern const unsigned int log10Table[];
 extern const unsigned int logTable[];
@@ -12,14 +13,22 @@ extern const unsigned short expTable[];
 inline float
 log10_h (half x)
 {
-    return *(float *)(&log10Table[x.bits()]);
+    int i = log10Table[x.bits()];
+    float f;
+    memcpy(&f, &i, sizeof(i));
+    return f;
+    //return *(float *)(&log10Table[x.bits()]);
 }
 
 
 inline float
 log_h (half x)
 {
-    return *(float *)(&logTable[x.bits()]);
+    int i = logTable[x.bits()];
+    float f;
+    memcpy(&f, &i, sizeof(i));
+    return f;
+    //return *(float *)(&logTable[x.bits()]);
 }
 
 

--- a/lib/dpx/dpx_raw.cc
+++ b/lib/dpx/dpx_raw.cc
@@ -206,7 +206,10 @@ bool dpx::isnull(uint8_t v) {
 }
 
 bool dpx::isnull(float32_t v) {
-	return *((uint32_t *)&v)==(uint32_t)-1;
+	uint32_t  u;
+    memcpy(&u, &v, sizeof(v));
+	return (u == (uint32_t)-1) ? true : false;
+	//return *((uint32_t *)&v)==(uint32_t)-1;
 }
 
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,7 +3,6 @@
     "version": "1.5.3",
     "dependencies": [
         "imath",
-        "openexr",
-        "tiff"
+        "openexr"
     ]
 }


### PR DESCRIPTION
- adds docker with link-time-optimization (LTO) enabled and strict aliasing warnings as errors
- addresses #146 strict aliasing issue with explicit memcpy() workaround, as described by https://github.com/isocpp/CppCoreGuidelines/issues/1987
- removes optional tiff from vcpkg.json and github vcpkg workflows.  Libtiff on vcpkg depends on liblzma.  Liblzma has security issue https://github.com/microsoft/vcpkg/issues/37839.  Hopefully this issue will be addressed in the future, which would allow vcpkg to be used with CTL and option libtiff again.