### PR TITLE
restore tiff to vcpkg github workflow

### DIFF
--- a/.github/workflows/windows_vcpkg_debug.yml
+++ b/.github/workflows/windows_vcpkg_debug.yml
@@ -30,11 +30,8 @@ jobs:
     - name: install dependencies - openexr
       run:  vcpkg install openexr 
 
-    # disabling tiff due to security issue
-    # https://github.com/microsoft/vcpkg/issues/37871
-    # https://github.com/microsoft/vcpkg/issues/37839
-    #  - name: install dependencies - tiff
-    #  run:  vcpkg install tiff 
+    - name: install dependencies - tiff
+      run:  vcpkg install tiff 
 
     - name: check vcpkg install status
       run: vcpkg list
@@ -69,11 +66,8 @@ jobs:
     - name: install dependencies - openexr
       run:  vcpkg install openexr 
 
-    # disabling tiff due to security issue
-    # https://github.com/microsoft/vcpkg/issues/37871
-    # https://github.com/microsoft/vcpkg/issues/37839
-#    - name: install dependencies - tiff
- #     run:  vcpkg install tiff 
+    - name: install dependencies - tiff
+      run:  vcpkg install tiff 
 
     - name: check vcpkg install status
       run: vcpkg list

--- a/.github/workflows/windows_vcpkg_release.yml
+++ b/.github/workflows/windows_vcpkg_release.yml
@@ -30,11 +30,8 @@ jobs:
     - name: install dependencies - openexr
       run:  vcpkg install openexr:x64-windows
 
-    # disabling tiff due to security issue
-    # https://github.com/microsoft/vcpkg/issues/37871
-    # https://github.com/microsoft/vcpkg/issues/37839
-    #- name: install dependencies - tiff
-    #  run:  vcpkg install tiff:x64-windows
+    - name: install dependencies - tiff
+      run:  vcpkg install tiff:x64-windows
 
     - name: check vcpkg install status
       run: vcpkg list
@@ -69,11 +66,8 @@ jobs:
     - name: install dependencies - openexr
       run:  vcpkg install openexr:x64-windows
 
-    # disabling tiff due to security issue
-    # https://github.com/microsoft/vcpkg/issues/37871
-    # https://github.com/microsoft/vcpkg/issues/37839
-    #- name: install dependencies - tiff
-    #  run:  vcpkg install tiff:x64-windows
+    - name: install dependencies - tiff
+      run:  vcpkg install tiff:x64-windows
 
     - name: check vcpkg install status
       run: vcpkg list

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,6 +3,7 @@
     "version": "1.5.3",
     "dependencies": [
         "imath",
-        "openexr"
+        "openexr",
+        "tiff"
     ]
 }


### PR DESCRIPTION
restores tiff to vcpkg github workflow that was removed in #147 due to a security issue