### PR TITLE
issues/0155 - typo in set_target_properties() in /lib/dpx/CMakeLists.txt

### DIFF
--- a/lib/dpx/CMakeLists.txt
+++ b/lib/dpx/CMakeLists.txt
@@ -35,7 +35,7 @@ target_link_libraries(ctldpx
 #          $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
 #    )
 
-set_target_properties(IlmCtlSimd
+set_target_properties(ctldpx
 	PROPERTIES
 		VERSION ${CTL_VERSION}
 		SOVERSION ${CTL_VERSION}


### PR DESCRIPTION
fixes #155 - typo in set_target_properties() in /lib/dpx/CMakeLists.txt