### PR TITLE
Issues/0134 openexr2 shared iex_debug trap

### DIFF
--- a/.github/workflows/docker_linuxes.yml
+++ b/.github/workflows/docker_linuxes.yml
@@ -203,3 +203,13 @@ jobs:
 
     - name: Run unit tests (ctest) within the Docker image
       run: docker run ctl:latest sh -c "cd ./build && ctest"
+
+  ubuntu-openexr2-shared:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the Docker image
+        run: docker build --no-cache --rm -f ./docker/Dockerfile_ubuntu_22.04_openexr2_shared -t ctl:latest .
+  
+      - name: Run unit tests (ctest) within the Docker image
+        run: docker run ctl:latest sh -c "cd ./build && ctest"  

--- a/.github/workflows/mac_release_shared.yml
+++ b/.github/workflows/mac_release_shared.yml
@@ -1,0 +1,184 @@
+name: macOS-Release-shared
+
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'doc/**'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'doc/**'
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+
+  build-openexr2:
+
+    runs-on: macos-latest
+
+    steps:
+
+    # - name: uninstall openexr 
+    #   run:  brew uninstall --ignore-dependencies openexr 
+
+    # - name: uninstall imath 
+    #   run:  brew uninstall --ignore-dependencies imath
+
+    - name: install dependencies - openexr v2.5
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+        cd openexr &&
+        git checkout RB-2.5 &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=ON .. &&
+        make &&
+        sudo make install
+
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_SHARED_LIBS=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+  
+  build-openexr3:
+    runs-on: macos-latest
+
+    steps:
+
+    - name: install dependencies - imath
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/Imath.git &&
+        cd Imath &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=ON .. &&
+        make &&
+        sudo make install
+
+    - name: install dependencies - openexr v3.1
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+        cd openexr &&
+        git checkout RB-3.1 &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=ON .. &&
+        make &&
+        sudo make install
+
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_SHARED_LIBS=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+  test-openexr2:
+
+    runs-on: macos-latest
+
+    steps:
+
+    # - name: uninstall openexr 
+    #   run:  brew uninstall --ignore-dependencies openexr 
+
+    # - name: uninstall imath 
+    #   run:  brew uninstall --ignore-dependencies imath
+
+    - name: install dependencies - openexr v2.5
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+        cd openexr &&
+        git checkout RB-2.5 &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=ON .. &&
+        make &&
+        sudo make install
+
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_SHARED_LIBS=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} 
+
+    - name: Install
+      run: sudo cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} 
+    
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -V --output-on-failure 
+  
+  test-openexr3:
+    runs-on: macos-latest
+
+    steps:
+
+    - name: install dependencies - imath
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/Imath.git &&
+        cd Imath &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=ON .. &&
+        make &&
+        sudo make install
+
+    - name: install dependencies - openexr v3.1
+      run:  |
+        cd ..
+        git clone https://github.com/AcademySoftwareFoundation/openexr.git &&
+        cd openexr &&
+        git checkout RB-3.1 &&
+        mkdir build &&
+        cd build &&
+        cmake -DBUILD_SHARED_LIBS=ON .. &&
+        make &&
+        sudo make install
+
+    - uses: actions/checkout@v4
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_SHARED_LIBS=ON
+
+    - name: Build
+      # Build your program with the given configuration
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} 
+
+    - name: Install
+      run: sudo cmake --install ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+    
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest -V --output-on-failure 
+

--- a/ctlrender/CMakeLists.txt
+++ b/ctlrender/CMakeLists.txt
@@ -21,9 +21,15 @@ target_link_libraries(ctlrender
 		IlmCtl
 		ctldpx
 	    # For OpenEXR/Imath 3.x:
-          $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
-        # For OpenEXR 2.4/2.5:
-          $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+		$<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+		$<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+		$<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+	  # For OpenEXR 2.4/2.5:
+		$<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+		$<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+		$<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+		$<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+		$<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
 )
 
 if( OpenEXR_FOUND )

--- a/docker/Dockerfile_ubuntu_22.04_openexr2_shared
+++ b/docker/Dockerfile_ubuntu_22.04_openexr2_shared
@@ -1,0 +1,44 @@
+FROM ubuntu:22.04
+
+RUN apt-get update
+
+# disable interactive install 
+ENV DEBIAN_FRONTEND noninteractive
+
+# install developement tools
+RUN apt-get -y install cmake
+RUN apt-get -y install g++
+RUN apt-get -y install git
+
+# install CTL dependencies
+#RUN apt-get -y install libopenexr-dev
+#RUN apt-get -y install libtiff-dev
+
+# install CTL dependencies - zlib
+RUN apt-get -y install zlib1g-dev
+
+# install CTL dependecies - openexr
+WORKDIR /usr/src/
+RUN git clone https://github.com/AcademySoftwareFoundation/openexr.git
+WORKDIR /usr/src/openexr
+RUN git checkout RB-2.5 
+WORKDIR /usr/src/openexr/build
+RUN cmake ..  -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF -DOPENEXR_BUILD_TOOLS=OFF -DOPENEXR_INSTALL_EXAMPLES=OFF
+RUN make
+RUN make install
+
+# build CTL
+WORKDIR /usr/src/CTL
+COPY . .
+WORKDIR /usr/src/CTL/build
+RUN rm -R * || true
+RUN cmake -DBUILD_SHARED_LIBS=ON ..
+RUN make
+RUN make install
+
+# add /usr/local/lib to the LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+# finalize docker environment
+WORKDIR /usr/src/CTL
+

--- a/lib/IlmCtl/CMakeLists.txt
+++ b/lib/IlmCtl/CMakeLists.txt
@@ -26,22 +26,19 @@ target_include_directories(IlmCtl
 		${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-if( IlmBase_FOUND )
-	target_link_libraries (IlmCtl
+target_link_libraries (IlmCtl
     PRIVATE
+        # For OpenEXR/Imath 3.x:
+          $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+          $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+          $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
         # For OpenEXR 2.4/2.5:
+          $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+          $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
           $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
           $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
           $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
     )
-else()
-	target_link_libraries (IlmCtl
-	PRIVATE
-	# For OpenEXR/Imath 3.x:
-	  $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
-	  $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
-	)
-endif()
 
 set_target_properties(IlmCtl
 	PROPERTIES

--- a/lib/IlmCtlMath/CMakeLists.txt
+++ b/lib/IlmCtlMath/CMakeLists.txt
@@ -11,25 +11,21 @@ target_include_directories(IlmCtlMath
 		${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-if(IlmBase_FOUND)
-	target_link_libraries(IlmCtlMath
+target_link_libraries (IlmCtlMath
 	PUBLIC
 		IlmCtl
-	PUBLIC
-		# For OpenEXR 2.4/2.5:
-        $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
-        $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
-	)	
-else()
-	target_link_libraries(IlmCtlMath
-	PUBLIC
-		IlmCtl
-	PUBLIC
-		# For OpenEXR/Imath 3.x:
-        $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
-        $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
-	)
-endif()
+    PRIVATE
+        # For OpenEXR/Imath 3.x:
+          $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+          $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+          $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+        # For OpenEXR 2.4/2.5:
+          $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+          $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+          $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+          $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+          $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+    )
 
 set_target_properties(IlmCtlMath
 	PROPERTIES

--- a/lib/IlmCtlSimd/CMakeLists.txt
+++ b/lib/IlmCtlSimd/CMakeLists.txt
@@ -73,6 +73,17 @@ target_link_libraries(IlmCtlSimd
 	PUBLIC
 		IlmCtlMath
 		IlmCtl
+	PRIVATE
+        # For OpenEXR/Imath 3.x:
+          $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+          $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+          $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+        # For OpenEXR 2.4/2.5:
+          $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+          $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+          $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+          $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+          $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
 )
 
 set_target_properties(IlmCtlSimd

--- a/lib/IlmImfCtl/CMakeLists.txt
+++ b/lib/IlmImfCtl/CMakeLists.txt
@@ -22,17 +22,17 @@ target_include_directories(IlmImfCtl
 target_link_libraries (IlmImfCtl
 	PUBLIC
 		IlmCtl
-  PUBLIC
-        # For OpenEXR/Imath 3.x:
-          $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
-#          $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
-          $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
-        # For OpenEXR 2.4/2.5:
-          $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
- #         $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
-          $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
-          $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
-          $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
+  PRIVATE
+    # For OpenEXR/Imath 3.x:
+      $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+      $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+      $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+    # For OpenEXR 2.4/2.5:
+      $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+      $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+      $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+      $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+      $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
     )
 
 set_target_properties(IlmImfCtl

--- a/unittest/IlmCtl/CMakeLists.txt
+++ b/unittest/IlmCtl/CMakeLists.txt
@@ -20,6 +20,17 @@ target_link_libraries(IlmCtlTest
 	PRIVATE
 		IlmCtlSimd
 		IlmCtl
+	PRIVATE
+    # For OpenEXR/Imath 3.x:
+      $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+      $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+      $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+    # For OpenEXR 2.4/2.5:
+      $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+      $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+      $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+      $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+      $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
 )
 
 add_test(IlmCtl IlmCtlTest)

--- a/unittest/IlmCtlMath/CMakeLists.txt
+++ b/unittest/IlmCtlMath/CMakeLists.txt
@@ -15,6 +15,17 @@ target_link_libraries(IlmCtlMathTest
 	PRIVATE
 		IlmCtlMath
 		IlmCtl
+	PRIVATE
+    # For OpenEXR/Imath 3.x:
+      $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+      $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+      $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+    # For OpenEXR 2.4/2.5:
+      $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+      $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+      $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+      $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+      $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
 )
 
 add_test(IlmCtlMath IlmCtlMathTest)

--- a/unittest/IlmImfCtl/CMakeLists.txt
+++ b/unittest/IlmImfCtl/CMakeLists.txt
@@ -17,6 +17,17 @@ target_link_libraries( IlmImfCtlTest
 		IlmCtlSimd
 		IlmCtlMath
 		IlmCtl
+	PRIVATE
+    # For OpenEXR/Imath 3.x:
+      $<$<TARGET_EXISTS:OpenEXR::OpenEXR>:OpenEXR::OpenEXR>
+      $<$<TARGET_EXISTS:Imath::Imath>:Imath::Imath>
+      $<$<TARGET_EXISTS:Imath::Half>:Imath::Half>
+    # For OpenEXR 2.4/2.5:
+      $<$<TARGET_EXISTS:OpenEXR::IlmImf>:OpenEXR::IlmImf>
+      $<$<TARGET_EXISTS:IlmBase::Imath>:IlmBase::Imath>
+      $<$<TARGET_EXISTS:IlmBase::Half>:IlmBase::Half>
+      $<$<TARGET_EXISTS:IlmBase::IlmThread>:IlmBase::IlmThread>
+      $<$<TARGET_EXISTS:IlmBase::Iex>:IlmBase::Iex>
 )
 
 add_test( IlmImfCtl IlmImfCtlTest )


### PR DESCRIPTION
- adds OpenEXR target link libraries to CMakeLists.txt as recommended by OpenEXR Porting Guide https://openexr.com/en/latest/PortingGuide.html
- fixes undefined symbols issue described in #134 that seems to occur when building OpenEXR and CTL using shared libraries, `-DBUILD_SHARED_LIBS=ON`

1. 
```
[ 68%] Building CXX object ctlrender/CMakeFiles/ctlrender.dir/format.cc.o
[ 69%] Building CXX object ctlrender/CMakeFiles/ctlrender.dir/compression.cc.o
[ 70%] Linking CXX executable ctlrender
ld: Undefined symbols:
  half::_eLut, referenced from:
      half::half(float) in exr_file.cc.o
  half::convert(int), referenced from:
      half::half(float) in exr_file.cc.o
  half::_toFloat, referenced from:
      half::operator float() const in libIlmCtlSimd.a[14](CtlSimdStdLibLookupTable.cpp.o)
```

2.
```
[ 23%] Building CXX object lib/IlmCtlMath/CMakeFiles/IlmCtlMath.dir/CtlRbfInterpolator.cpp.o
[ 24%] Linking CXX shared library libIlmCtlMath.dylib
Undefined symbols for architecture x86_64:
  "iex_debugTrap()", referenced from:
      double Ctl::CG<double, Ctl::LSSOperator<double, Ctl::CRSOperator<double> >, Ctl::NullLinearOperator>::operator()<std::__1::__wrap_iter<double*>, std::__1::__wrap_iter<double*> >(std::__1::__wrap_iter<double*>, std::__1::__wrap_iter<double*>, std::__1::__wrap_iter<double*>, std::__1::__wrap_iter<double*>) const in CtlRbfInterpolator.cpp.o
  "Iex_2_5::ArgExc::ArgExc(std::__1::basic_stringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >&)", referenced from:
      double Ctl::CG<double, Ctl::LSSOperator<double, Ctl::CRSOperator<double> >, Ctl::NullLinearOperator>::operator()<std::__1::__wrap_iter<double*>, std::__1::__wrap_iter<double*> >(std::__1::__wrap_iter<double*>, std::__1::__wrap_iter<double*>, std::__1::__wrap_iter<double*>, std::__1::__wrap_iter<double*>) const in CtlRbfInterpolator.cpp.o
```

      
  