### PR TITLE
remove centos7 from github workflow, centos7 is EOL 2024-06-30

### DIFF
--- a/.github/workflows/docker_linuxes.yml
+++ b/.github/workflows/docker_linuxes.yml
@@ -120,18 +120,6 @@ jobs:
     - name: Run unit tests (ctest) within the Docker image
       run: docker run ctl:latest sh -c "cd ./build && ctest"
 
-  centos7:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker build --no-cache --rm -f ./docker/Dockerfile_centos_7 -t ctl:latest .
-
-    - name: Run unit tests (ctest) within the Docker image
-      run: docker run ctl:latest sh -c "cd ./build && ctest"
-
   redhat-ubi8:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
- removing from Centos7 from github workflow because Centos7 is now End-of-Life, https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/ 