### PR TITLE
Disambiguate `clamp` calls in `exrToDpx.cpp`

### DIFF
--- a/OpenEXR_CTL/exrdpx/exrToDpx.cpp
+++ b/OpenEXR_CTL/exrdpx/exrToDpx.cpp
@@ -169,13 +169,13 @@ writePixels
 	    const Rgba &pixel = pixels[y][x];
 
 	    unsigned int r =
-		(unsigned int) (clamp (float (pixel.r), 0.0f, 1023.0f) + 0.5f);
+		(unsigned int) (Imath::clamp (float (pixel.r), 0.0f, 1023.0f) + 0.5f);
 
 	    unsigned int g =
-		(unsigned int) (clamp (float (pixel.g), 0.0f, 1023.0f) + 0.5f);
+		(unsigned int) (Imath::clamp (float (pixel.g), 0.0f, 1023.0f) + 0.5f);
 
 	    unsigned int b =
-		(unsigned int) (clamp (float (pixel.b), 0.0f, 1023.0f) + 0.5f);
+		(unsigned int) (Imath::clamp (float (pixel.b), 0.0f, 1023.0f) + 0.5f);
 
 	    unsigned int word = (r << 22) | (g << 12) | (b << 2);
 


### PR DESCRIPTION
C++17 now has `std::clamp`[^1], so the calls to `clamp` in this file
cause the compiler to error with[^2]

      /tmp/ctl-20240930-89937-yvomao/CTL-ctl-1.5.3/OpenEXR_CTL/exrdpx/exrToDpx.cpp:172:19: error: call to 'clamp' is ambiguous
        172 |                 (unsigned int) (clamp (float (pixel.r), 0.0f, 1023.0f) + 0.5f);
            |                                 ^~~~~
      /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/__algorithm/clamp.h:35:1: note: candidate function [with _Tp = float]
         35 | clamp(_LIBCPP_LIFETIMEBOUND const _Tp& __v,
            | ^
      /opt/homebrew/include/Imath/ImathFun.h:77:1: note: candidate function [with T = float]
         77 | clamp (T a, T l, T h) IMATH_NOEXCEPT
            | ^
      /tmp/ctl-20240930-89937-yvomao/CTL-ctl-1.5.3/OpenEXR_CTL/exrdpx/exrToDpx.cpp:175:19: error: call to 'clamp' is ambiguous
        175 |                 (unsigned int) (clamp (float (pixel.g), 0.0f, 1023.0f) + 0.5f);
            |                                 ^~~~~
      /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/__algorithm/clamp.h:35:1: note: candidate function [with _Tp = float]
         35 | clamp(_LIBCPP_LIFETIMEBOUND const _Tp& __v,
            | ^
      /opt/homebrew/include/Imath/ImathFun.h:77:1: note: candidate function [with T = float]
         77 | clamp (T a, T l, T h) IMATH_NOEXCEPT
            | ^
      /tmp/ctl-20240930-89937-yvomao/CTL-ctl-1.5.3/OpenEXR_CTL/exrdpx/exrToDpx.cpp:178:19: error: call to 'clamp' is ambiguous
        178 |                 (unsigned int) (clamp (float (pixel.b), 0.0f, 1023.0f) + 0.5f);
            |                                 ^~~~~
      /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/c++/v1/__algorithm/clamp.h:35:1: note: candidate function [with _Tp = float]
         35 | clamp(_LIBCPP_LIFETIMEBOUND const _Tp& __v,
            | ^
      /opt/homebrew/include/Imath/ImathFun.h:77:1: note: candidate function [with T = float]
         77 | clamp (T a, T l, T h) IMATH_NOEXCEPT
            | ^
      3 errors generated.
      make[2]: *** [OpenEXR_CTL/exrdpx/CMakeFiles/exrdpx.dir/exrToDpx.cpp.o] Error 1

Both this code and `Imath::clamp` long predate `std::clamp`, so it seems
to me that `Imath::clamp` is what's intended here.

This fixes a build failure at Homebrew while rebuilding CTL for OpenEXR
3.3.0.[^3]

[^1]: https://en.cppreference.com/w/cpp/algorithm/clamp
[^2]: Logs available at https://github.com/Homebrew/homebrew-core/actions/runs/11113893071/job/30879442929?pr=192399#step:3:375
[^3]: See https://github.com/Homebrew/homebrew-core/pull/192399
