### PR TITLE
codeql/cpp-comparison-with-wider-type

### DIFF
--- a/ctlrender/tiff_file.cc
+++ b/ctlrender/tiff_file.cc
@@ -278,6 +278,7 @@ void tiff_read_multiplane(TIFF *t, float scale, ctl::dpx::fb<float> * pixels) {
 	uint32_t row;
 	uint32_t orientation_offset;
 	uint16_t d;
+	uint32_t e;
 
 	TIFFGetFieldDefaulted(t, TIFFTAG_IMAGEWIDTH, &w);
 	TIFFGetFieldDefaulted(t, TIFFTAG_IMAGELENGTH, &h);
@@ -300,8 +301,8 @@ void tiff_read_multiplane(TIFF *t, float scale, ctl::dpx::fb<float> * pixels) {
 		for(row=0; row<4; row++) {
 			if(row<samples_per_pixel) {
 				scanline_buffer_uint8[row]=(uint8_t *)alloca(scanline_size);
-				for(d=0; d<w; d++) {
-					scanline_buffer_uint8[row][d]= row==3 ? 255 : 0;
+				for(e=0; e<w; e++) {
+					scanline_buffer_uint8[row][e]= row==3 ? 255 : 0;
 				}
 			} else {
 				scanline_buffer_uint8[row]=NULL;
@@ -330,8 +331,8 @@ void tiff_read_multiplane(TIFF *t, float scale, ctl::dpx::fb<float> * pixels) {
 		for(row=0; row<4; row++) {
 			if(row<samples_per_pixel) {
 				scanline_buffer_uint16[row]=(uint16_t *)alloca(scanline_size);
-				for(d=0; d<w; d++) {
-					scanline_buffer_uint16[row][d]= row==3 ? 65535 : 0;
+				for(e=0; e<w; e++) {
+					scanline_buffer_uint16[row][e]= row==3 ? 65535 : 0;
 				}
 			} else {
 				scanline_buffer_uint16[row]=NULL;
@@ -358,8 +359,8 @@ void tiff_read_multiplane(TIFF *t, float scale, ctl::dpx::fb<float> * pixels) {
 		for(row=0; row<4; row++) {
 			if(row<samples_per_pixel) {
 				scanline_buffer_float[row]=(float *)alloca(scanline_size);
-				for(d=0; d<w; d++) {
-					scanline_buffer_float[row][d]= row==3 ? 1.0 : 0.0;
+				for(e=0; e<w; e++) {
+					scanline_buffer_float[row][e]= row==3 ? 1.0 : 0.0;
 				}
 			} else {
 				scanline_buffer_float[row]=NULL;

--- a/ctlrender/transform.cc
+++ b/ctlrender/transform.cc
@@ -699,6 +699,7 @@ void transform(const char *inputFile, const char *outputFile,
 	ctl_operation_t ctl_operation;
 	CTLParameters::const_iterator parameters_iter;
 	uint8_t i;
+	uint32_t j;
 	std::string error;
 	ctl::dpx::fb<float> image_buffer;
 
@@ -807,11 +808,11 @@ void transform(const char *inputFile, const char *outputFile,
 
 	char name[16];
 
-	for (i = 4; i < image_buffer.depth(); i++)
+	for (j = 4; j < image_buffer.depth(); j++)
 	{
 		memset(name, 0, sizeof(name));
-		snprintf(name, sizeof(name) - 1, "c%02dIn", i);
-		ctl_results.push_back(mkresult(name, NULL, image_buffer, i));
+		snprintf(name, sizeof(name) - 1, "c%02dIn", j);
+		ctl_results.push_back(mkresult(name, NULL, image_buffer, j));
 	}
 
 	for (operations_iter = ctl_operations.begin(); operations_iter != ctl_operations.end(); operations_iter++)

--- a/lib/dpx/dpx_rw.cc
+++ b/lib/dpx/dpx_rw.cc
@@ -268,7 +268,7 @@ void rwinfo::write_init(std::ostream *o, dpx *h) {
 }
 
 void rwinfo::find_home(dpx *h, uint8_t element, uint64_t size) {
-	uint8_t i;
+	uint16_t i;
 	rwinfo info;
 	uint64_t eof;
 	uint64_t actual_eof;


### PR DESCRIPTION
- fixes codeql cpp/comparison-with-wider-type

6 issues have been detected by CodeQL:

- [lib/dpx/dpx_rw.cc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2Fdpx%2Fdpx_rw.cc) :308

https://github.com/ampas/CTL/security/code-scanning/71

- [lib/dpx/dpx_rw.cc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2Fdpx%2Fdpx_rw.cc) :295

https://github.com/ampas/CTL/security/code-scanning/70

- [ctlrender/transform.cc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Actlrender%2Ftransform.cc) :810

https://github.com/ampas/CTL/security/code-scanning/69

- [ctlrender/tiff_file.cc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Actlrender%2Ftiff_file.cc) :361

https://github.com/ampas/CTL/security/code-scanning/68

- [ctlrender/tiff_file.cc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Actlrender%2Ftiff_file.cc) :333

https://github.com/ampas/CTL/security/code-scanning/67

- [ctlrender/tiff_file.cc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Actlrender%2Ftiff_file.cc) :303

https://github.com/ampas/CTL/security/code-scanning/66