### PR TITLE
codeql/cpp-wrong-type-format-argument

### DIFF
--- a/lib/IlmCtl/CtlType.cpp
+++ b/lib/IlmCtl/CtlType.cpp
@@ -132,10 +132,10 @@ void Type::childElementV(size_t *offset, TypePtr *type, const std::string path,
 			offsets=((SizeVector *)va_arg(ap, SizeVector *));
 			while(offsets->size()!=0) {
 				if(sizes.size()==0) {
-					throw(DatatypeExc("too many dimensions specified for matrix (or array) vector element (at least %d too many)", offsets->size()));
+					throw(DatatypeExc("too many dimensions specified for matrix (or array) vector element (at least %zu too many)", offsets->size()));
 				}
 				if(offset[0]>=sizes[0]) {
-					throw(DatatypeExc("out of range matrix (or array) vector element (%u>=%u)", offset[0], sizes[0]));
+					throw(DatatypeExc("out of range matrix (or array) vector element (%zu>=%zu)", offset[0], sizes[0]));
 				}
 				*offset=*offset+array_type->elementType()->objectSize()*((*offsets)[0]);
 				*type=array_type->elementType();
@@ -150,7 +150,7 @@ void Type::childElementV(size_t *offset, TypePtr *type, const std::string path,
 		}
 
 		if(u>=sizes[0]) {
-			throw(DatatypeExc("out of range matrix (or array) element specification (%u>=%u)", u, sizes[0]));
+			throw(DatatypeExc("out of range matrix (or array) element specification (%u>=%zu)", u, sizes[0]));
 		}
 
 		*offset=*offset+u*array_type->elementType()->objectSize();

--- a/lib/IlmCtl/CtlTypeStorage.cpp
+++ b/lib/IlmCtl/CtlTypeStorage.cpp
@@ -463,7 +463,7 @@ void TypeStorage::_set(const char *src, CDataType_e src_type,
 				out=out+type()->objectSize();
 			}
 		} else {
-			throw(DatatypeExc("unexpected data objectSize (%d)", data_type->objectSize()));
+			throw(DatatypeExc("unexpected data objectSize (%zu)", data_type->objectSize()));
 		}
 		return;
 	}
@@ -547,7 +547,7 @@ void TypeStorage::_get(char *dst, CDataType_e dst_type,
 				in=in+type()->objectSize();
 			}
 		} else {
-			throw(DatatypeExc("unexpected data objectSize (%d)", data_type->objectSize()));
+			throw(DatatypeExc("unexpected data objectSize (%zu)", data_type->objectSize()));
 		}
 		return;
 	}


### PR DESCRIPTION
- fixes codeql/cpp/wrong-type-format-argument issues
- CodeQL detects 6 issues:

https://github.com/ampas/CTL/security/code-scanning/92
[lib/IlmCtl/CtlTypeStorage.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2FIlmCtl%2FCtlTypeStorage.cpp) :466

https://github.com/ampas/CTL/security/code-scanning/91
[lib/IlmCtl/CtlTypeStorage.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2FIlmCtl%2FCtlTypeStorage.cpp) :550

https://github.com/ampas/CTL/security/code-scanning/90
[lib/IlmCtl/CtlType.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2FIlmCtl%2FCtlType.cpp) :153

https://github.com/ampas/CTL/security/code-scanning/89
[lib/IlmCtl/CtlType.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2FIlmCtl%2FCtlType.cpp) :138

https://github.com/ampas/CTL/security/code-scanning/88
[lib/IlmCtl/CtlType.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2FIlmCtl%2FCtlType.cpp) :138

https://github.com/ampas/CTL/security/code-scanning/87
[lib/IlmCtl/CtlType.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2FIlmCtl%2FCtlType.cpp) :135
