### PR TITLE
codeql/cpp/integer-multiplication-cast-to-long

### DIFF
--- a/OpenEXR_CTL/exr_ctl_exr/exrCtlExr.cpp
+++ b/OpenEXR_CTL/exr_ctl_exr/exrCtlExr.cpp
@@ -139,7 +139,7 @@ exrCtlExr (const char inFileName[],
     {
 	const Rgba *inPtr = &inPixels[0][0];
 	Rgba *outPtr = &outPixels[0][0];
-	size_t numPixels = w * h;
+	size_t numPixels = static_cast<size_t>(w) * h;
 
 	for (size_t i = 0; i < numPixels; ++i)
 	    (outPtr++)->a = (inPtr++)->a;

--- a/OpenEXR_CTL/exrdpx/exrToDpx.cpp
+++ b/OpenEXR_CTL/exrdpx/exrToDpx.cpp
@@ -105,7 +105,7 @@ writeHeader
     setU32 (sizeof (header), header.fileInfo.offsetToImageData, BO_BIG);
     strcpy (header.fileInfo.versionNumber, "V2.0");
 
-    setU32 (sizeof (header) + 4 * width * height,
+    setU32 (sizeof (header) + 4 * static_cast<unsigned long>(width) * height,
 	    header.fileInfo.fileSize,
 	    BO_BIG);
 

--- a/ctlrender/tiff_file.cc
+++ b/ctlrender/tiff_file.cc
@@ -486,7 +486,7 @@ void tiff_read_failsafe(TIFF *t, float scale, ctl::dpx::fb<float> *pixels) {
 	TIFFGetFieldDefaulted(t, TIFFTAG_IMAGELENGTH, &h);
 	pixels->init(w, h, 4);
 
-	temp_buffer=(uint8_t *)alloca(w*h*4);
+	temp_buffer=(uint8_t *)alloca((uint64_t)w*h*4);
 	TIFFReadRGBAImage(t, w, h, (uint32_t *)temp_buffer, 0);
 
 	for(i=0; i<h; i++) {

--- a/lib/IlmImfCtl/ImfCtlApplyTransforms.cpp
+++ b/lib/IlmImfCtl/ImfCtlApplyTransforms.cpp
@@ -487,8 +487,8 @@ applyTransforms
     // Determine how many samples we will process.
     //
 
-    size_t totalSamples = (transformWindow.max.x - transformWindow.min.x + 1) *
-			  (transformWindow.max.y - transformWindow.min.y + 1);
+    size_t totalSamples = (static_cast<size_t>(transformWindow.max.x) - static_cast<size_t>(transformWindow.min.x + 1)) *
+			  (static_cast<size_t>(transformWindow.max.y) - static_cast<size_t>(transformWindow.min.y + 1));
 
     if (totalSamples <= 0)
 	return;

--- a/lib/IlmImfCtl/ImfCtlApplyTransforms.cpp
+++ b/lib/IlmImfCtl/ImfCtlApplyTransforms.cpp
@@ -487,8 +487,8 @@ applyTransforms
     // Determine how many samples we will process.
     //
 
-    size_t totalSamples = (static_cast<size_t>(transformWindow.max.x) - static_cast<size_t>(transformWindow.min.x + 1)) *
-			  (static_cast<size_t>(transformWindow.max.y) - static_cast<size_t>(transformWindow.min.y + 1));
+	size_t totalSamples = static_cast<size_t>(transformWindow.max.x - transformWindow.min.x + 1) *
+	  static_cast<size_t>(transformWindow.max.y - transformWindow.min.y + 1);
 
     if (totalSamples <= 0)
 	return;

--- a/lib/dpx/dpx.tcc
+++ b/lib/dpx/dpx.tcc
@@ -80,7 +80,7 @@ void dpx::fb<T>::init(uint32_t width, uint32_t height, uint32_t depth) {
 
 	delete [] _data;
 
-	_length=_width*_height*_depth*sizeof(T);
+	_length=static_cast<uint64_t>(_width)*_height*_depth*sizeof(T);
 
 	_data=new T[width*height*depth];
 }
@@ -107,12 +107,12 @@ uint64_t dpx::fb<T>::length(void) const {
 
 template <class T>
 uint64_t dpx::fb<T>::count(void) const {
-	return _width*_height*_depth;
+	return static_cast<uint64_t>(_width)*static_cast<uint64_t>(_height)*static_cast<uint64_t>(_depth);
 }
 
 template <class T>
 uint64_t dpx::fb<T>::pixels(void) const {
-	return _width*_height;
+	return static_cast<uint64_t>(_width)*_height;
 }
 
 template <class T>
@@ -141,7 +141,7 @@ void dpx::fb<T>::swizzle(uint8_t descriptor, bool squish_alpha) {
 	T *i, *o;
 	T t;
 
-	count=width()*height();
+	count=static_cast<uint64_t>(width())*height();
 
 	i=_data;
 	o=_data;

--- a/lib/dpx/dpx_read.cc
+++ b/lib/dpx/dpx_read.cc
@@ -135,7 +135,7 @@ void unpack(dpx::fb<O> *out, const I *i, const rwinfo &ri) {
 		// XXX not supported
 	}
 
-	count=out->width()*out->depth();
+	count= static_cast<uint64_t>(out->width())*out->depth();
 	for(u=0; u<out->height(); u++) {
 		onbit=0;
 		for(v=0; v<count; v++) {

--- a/unittest/IlmCtlMath/testGaussRec.cpp
+++ b/unittest/IlmCtlMath/testGaussRec.cpp
@@ -82,9 +82,9 @@ runTestGaussian(int numSamples, int numTests)
 	p[s][0][1] = (float) rand() / (float) RAND_MAX;
 	p[s][0][2] = (float) rand() / (float) RAND_MAX;
 	
-	p[s][1][0] = exp( -p[s][0][0]*p[s][0][0] * var);
-	p[s][1][1] = exp( -p[s][0][1]*p[s][0][1] * var);
-	p[s][1][2] = exp( -p[s][0][2]*p[s][0][2] * var);
+	p[s][1][0] = exp( -static_cast<double>(p[s][0][0])*static_cast<double>(p[s][0][0]) * var);
+	p[s][1][1] = exp( -static_cast<double>(p[s][0][1])*static_cast<double>(p[s][0][1]) * var);
+	p[s][1][2] = exp( -static_cast<double>(p[s][0][2])*static_cast<double>(p[s][0][2]) * var);
     }
     
     Ctl::RbfInterpolator rbfItp(numSamples, p);


### PR DESCRIPTION
- fixes 12 codeql/cpp/integer-multiplication-cast-to-long issues

https://github.com/ampas/CTL/security/code-scanning/86
[unittest/IlmCtlMath/testGaussRec.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Aunittest%2FIlmCtlMath%2FtestGaussRec.cpp) :87

https://github.com/ampas/CTL/security/code-scanning/85
[unittest/IlmCtlMath/testGaussRec.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Aunittest%2FIlmCtlMath%2FtestGaussRec.cpp) :86

https://github.com/ampas/CTL/security/code-scanning/84
[unittest/IlmCtlMath/testGaussRec.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Aunittest%2FIlmCtlMath%2FtestGaussRec.cpp) :85

https://github.com/ampas/CTL/security/code-scanning/83
[lib/dpx/dpx_read.cc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2Fdpx%2Fdpx_read.cc) :138

https://github.com/ampas/CTL/security/code-scanning/82
[lib/dpx/dpx.tcc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2Fdpx%2Fdpx.tcc) :110

https://github.com/ampas/CTL/security/code-scanning/81
[lib/IlmImfCtl/ImfCtlApplyTransforms.cp...](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2FIlmImfCtl%2FImfCtlApplyTransforms.cpp) :490

https://github.com/ampas/CTL/security/code-scanning/80
[lib/dpx/dpx.tcc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2Fdpx%2Fdpx.tcc) :144

https://github.com/ampas/CTL/security/code-scanning/79
[ctlrender/tiff_file.cc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Actlrender%2Ftiff_file.cc) :489

https://github.com/ampas/CTL/security/code-scanning/78
[lib/dpx/dpx.tcc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2Fdpx%2Fdpx.tcc) :115

https://github.com/ampas/CTL/security/code-scanning/77
[lib/dpx/dpx.tcc](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3Alib%2Fdpx%2Fdpx.tcc) :83

https://github.com/ampas/CTL/security/code-scanning/76
[OpenEXR_CTL/exrdpx/exrToDpx.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3AOpenEXR_CTL%2Fexrdpx%2FexrToDpx.cpp) :108

https://github.com/ampas/CTL/security/code-scanning/75
[OpenEXR_CTL/exr_ctl_exr/exrCtlExr.cpp](https://github.com/ampas/CTL/security/code-scanning?query=is%3Aopen+branch%3Amaster+path%3AOpenEXR_CTL%2Fexr_ctl_exr%2FexrCtlExr.cpp) :142