### PR TITLE
IlmCtl: report BoolTypeEnum from BoolType::cDataType

### DIFF
--- a/lib/IlmCtl/CtlType.h
+++ b/lib/IlmCtl/CtlType.h
@@ -364,7 +364,7 @@ class BoolType: public DataType
     virtual bool		canPromoteFrom (const TypePtr &t) const;
     virtual bool		canCastFrom (const TypePtr &t) const;
 
-	virtual CDataType_e cDataType() const { return IntTypeEnum; };
+	virtual CDataType_e cDataType() const { return BoolTypeEnum; };  // storage is sizeof(bool), not sizeof(int)
 
     virtual ExprNodePtr		evaluate (LContext &lcontext,
 					  const ExprNodePtr &expr) const;

--- a/unittest/IlmCtl/CMakeLists.txt
+++ b/unittest/IlmCtl/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
 	testExamples.cpp
 	testHugeInit.cpp
 	testParser.cpp
+	testBoolStorage.cpp
 	testVarying.cpp
 	testVaryingLookup.cpp
 	testVaryingReturn.cpp
@@ -37,6 +38,7 @@ add_test(IlmCtl IlmCtlTest)
 
 file(COPY
 	common.ctl
+	testBoolStorage.ctl
 	example.ctl
 	testArray.ctl
 	testCast.ctl

--- a/unittest/IlmCtl/main.cpp
+++ b/unittest/IlmCtl/main.cpp
@@ -55,6 +55,7 @@
 
 #include <testEndOfLine.h>
 #include <testParser.h>
+#include <testBoolStorage.h>
 #include <testCppCall.h>
 #include <testVarying.h>
 #include <testHugeInit.h>
@@ -74,6 +75,7 @@ main (int argc, char *argv[])
 
     TEST (testEndOfLine);
     TEST (testParser);
+    TEST (testBoolStorage);
     TEST (testExamples);
     TEST (testCppCall);
     TEST (testVarying);

--- a/unittest/IlmCtl/testBoolStorage.cpp
+++ b/unittest/IlmCtl/testBoolStorage.cpp
@@ -1,0 +1,118 @@
+///////////////////////////////////////////////////////////////////////////
+// Copyright Contributors to the CTL project.
+///////////////////////////////////////////////////////////////////////////
+
+//
+// A CTL bool occupies sizeof(bool), which SimdBoolType reports as its
+// objectSize.  TypeStorage picks the width of its copy from the type's
+// cDataType(), so a bool that advertises IntTypeEnum makes the typed
+// accessors read four bytes out of a one-byte object and take the three
+// bytes after it into the value.
+//
+// Existing tests never caught that because they reach the interpreter's
+// buffers through FunctionArg::data() and memcpy, which bypasses the typed
+// path entirely.  This test goes through set() and get(), and poisons the
+// struct first so the bytes after the bool are non-zero.  With a
+// wrongly-sized read the poison is what comes back, and the check below is
+// the difference between reading one byte and reading four.
+//
+
+#include <CtlSimdInterpreter.h>
+#include <CtlFunctionCall.h>
+#include <CtlType.h>
+
+#include <testBoolStorage.h>
+
+#include <iostream>
+#include <stdlib.h>
+#include <string.h>
+
+//
+// Release builds define NDEBUG, which turns assert() into nothing, so a test
+// written with assert() reports success no matter what it observed.  Check
+// through something that survives the optimizer settings instead.
+//
+#define REQUIRE(x)                                                      \
+    do {                                                                \
+        if (!(x)) {                                                     \
+            std::cerr << "REQUIRE failed: " #x " at " << __FILE__       \
+                      << ":" << __LINE__ << std::endl;                  \
+            exit (1);                                                   \
+        }                                                               \
+    } while (0)
+
+using namespace Ctl;
+using namespace std;
+
+namespace {
+
+void
+testFalseSurvivesPoisonedPadding ()
+{
+    cout << "  bool read back through the typed accessors" << endl;
+
+    SimdInterpreter interp;
+    interp.loadFile ("testBoolStorage.ctl");
+
+    FunctionCallPtr func = interp.newFunctionCall ("boolStorage");
+    FunctionArgPtr  in   = func->findInputArg ("i");
+    REQUIRE (in);
+
+    // Fill the whole struct, padding included, with a non-zero pattern.  Any
+    // read wider than the bool now returns something non-zero.
+    memset (in->data(), 0xff, in->type()->objectSize());
+
+    const bool f = false;
+    in->set (&f, 0, 0, 1, "flag");
+
+    bool readBack = true;
+    in->get (&readBack, 0, 0, 1, "flag");
+
+    // Reading four bytes here yields 0x00ffffff, which is true.
+    REQUIRE (readBack == false);
+
+    const bool t = true;
+    in->set (&t, 0, 0, 1, "flag");
+    readBack = false;
+    in->get (&readBack, 0, 0, 1, "flag");
+    REQUIRE (readBack == true);
+}
+
+
+void
+testBoolDoesNotDisturbItsNeighbour ()
+{
+    cout << "  writing a bool leaves the next member intact" << endl;
+
+    SimdInterpreter interp;
+    interp.loadFile ("testBoolStorage.ctl");
+
+    FunctionCallPtr func = interp.newFunctionCall ("boolStorage");
+    FunctionArgPtr  in   = func->findInputArg ("i");
+    REQUIRE (in);
+
+    const int marker = 0x5a5a5a5a;
+    in->set (&marker, 0, 0, 1, "marker");
+
+    const bool f = false;
+    in->set (&f, 0, 0, 1, "flag");
+
+    // A write wider than the bool would have run into marker.
+    int readBack = 0;
+    in->get (&readBack, 0, 0, 1, "marker");
+    REQUIRE (readBack == marker);
+}
+
+} // namespace
+
+
+void
+testBoolStorage ()
+{
+    cout << "Testing bool storage width" << endl;
+
+    testFalseSurvivesPoisonedPadding ();
+    testBoolDoesNotDisturbItsNeighbour ();
+
+    cout << "ok" << endl;
+}

--- a/unittest/IlmCtl/testBoolStorage.cpp
+++ b/unittest/IlmCtl/testBoolStorage.cpp
@@ -91,15 +91,29 @@ testBoolDoesNotDisturbItsNeighbour ()
     FunctionArgPtr  in   = func->findInputArg ("i");
     REQUIRE (in);
 
+    StructTypePtr st = in->type().cast<StructType>();
+    REQUIRE (st);
+
+    // Reach the second member through its recorded offset rather than through
+    // a "/" path.  Addressing it by path goes via Type::childElementV, which
+    // has its own offset bug on this branch, and this test is about the width
+    // of the bool write, not about path resolution.
+    size_t markerOffset = 0;
+    for (size_t i = 0; i < st->members().size(); ++i)
+        if (st->members()[i].name == "marker")
+            markerOffset = st->members()[i].offset;
+    REQUIRE (markerOffset != 0);
+
+    char* base = (char*) in->data();
     const int marker = 0x5a5a5a5a;
-    in->set (&marker, 0, 0, 1, "marker");
+    memcpy (base + markerOffset, &marker, sizeof (marker));
 
     const bool f = false;
     in->set (&f, 0, 0, 1, "flag");
 
-    // A write wider than the bool would have run into marker.
+    // A write wider than the bool would have reached into marker.
     int readBack = 0;
-    in->get (&readBack, 0, 0, 1, "marker");
+    memcpy (&readBack, base + markerOffset, sizeof (readBack));
     REQUIRE (readBack == marker);
 }
 

--- a/unittest/IlmCtl/testBoolStorage.ctl
+++ b/unittest/IlmCtl/testBoolStorage.ctl
@@ -1,0 +1,15 @@
+// Fixture for testBoolStorage.  The struct puts a bool ahead of an int so the
+// bool is followed by padding, which is what a wrongly-sized read walks into.
+
+struct Flagged
+{
+    bool flag;
+    int  marker;
+};
+
+void
+boolStorage (output Flagged o, input Flagged i)
+{
+    o.flag   = i.flag;
+    o.marker = i.marker;
+}

--- a/unittest/IlmCtl/testBoolStorage.h
+++ b/unittest/IlmCtl/testBoolStorage.h
@@ -1,0 +1,6 @@
+#ifndef INCLUDED_TEST_BOOL_STORAGE_H
+#define INCLUDED_TEST_BOOL_STORAGE_H
+
+void testBoolStorage ();
+
+#endif


### PR DESCRIPTION
A CTL bool occupies `sizeof(bool)` -- `SimdBoolType::objectSize()` returns exactly that. But `BoolType::cDataType()` returned `IntTypeEnum`, and `TypeStorage` sizes its copies from `cDataType()`. So the typed accessors read four bytes out of a one-byte object:

```cpp
} else if(in_type==IntTypeEnum) {
    if(out_type==BoolTypeEnum) {
        *((bool *)out)=!!*((int *)in);   // reads 4 bytes from a 1-byte object
```

The three bytes after the bool get folded into the value, so a bool whose neighbouring storage is non-zero reads back as `true` no matter what was written.

## Why it has gone unnoticed

Whether those neighbouring bytes happen to be zero depends on frame layout, so this reproduces on Linux x86_64 while macOS arm64 returns the right answer by luck.

The existing tests also could not have caught it. They reach the interpreter's buffers through `FunctionArg::data()` and `memcpy`, which bypasses the typed path entirely.

## The fix

Report `BoolTypeEnum`. `TypeStorage` already carries branches for it, and the change is contained: the only other places in the tree that switch on `cDataType()` are two sites in `CtlType.cpp`. Nothing in the SIMD interpreter, ctlrender, or OpenEXR_CTL consults it.

## Test

`testBoolStorage` covers both directions. It poisons the whole struct so that any read wider than the bool returns the poison, then checks that `false` survives a set and get, and that writing the bool leaves the following struct member intact.

Confirmed to fail without the fix and pass with it:

```
REQUIRE failed: readBack == false at unittest/IlmCtl/testBoolStorage.cpp:72
```

It uses an explicit check rather than `assert`. Release builds define `NDEBUG`, which compiles `assert` out, so an assert-based test reports success regardless of what it observed. Worth knowing more broadly: the same is true of the existing suite, where for example `testVarying.cpp` has 125 asserts that do nothing in a Release build.

## Verification

- Full suite passes: 232 of 232.
- The new test fails with the fix reverted and passes with it applied.

Closes #206
