### PR TITLE
Add tetrahedral interpolation for 3D table lookups and tests.

### DIFF
--- a/lib/IlmCtlMath/CtlLookupTable.cpp
+++ b/lib/IlmCtlMath/CtlLookupTable.cpp
@@ -54,7 +54,8 @@
 
 //-----------------------------------------------------------------------------
 //
-//	1D and 3D table lookups with linear and trilinear interpolation.
+//	1D and 3D table lookups with linear, trilinear and tetrahedral
+//	interpolation.
 //
 //-----------------------------------------------------------------------------
 
@@ -235,7 +236,82 @@ lookup3D
 }
 
 
-float	
+V3f
+lookup3DTetra
+    (const V3f table[],
+     const V3i &size,
+     const V3f &pMin,
+     const V3f &pMax,
+     const V3f &p)
+{
+    int iMax = size.x - 1;
+    float r = (clamp (p.x, pMin.x, pMax.x) - pMin.x) / (pMax.x - pMin.x) * iMax;
+
+    int i, i1;
+    float u, u1;
+    indicesAndWeights (r, iMax, i, i1, u, u1);
+
+    int jMax = size.y - 1;
+    float s = (clamp (p.y, pMin.y, pMax.y) - pMin.y) / (pMax.y - pMin.y) * jMax;
+
+    int j, j1;
+    float v, v1;
+    indicesAndWeights (s, jMax, j, j1, v, v1);
+
+    int kMax = size.z - 1;
+    float t = (clamp (p.z, pMin.z, pMax.z) - pMin.z) / (pMax.z - pMin.z) * kMax;
+
+    int k, k1;
+    float w, w1;
+    indicesAndWeights (t, kMax, k, k1, w, w1);
+
+    const V3f &c000 = table[(i  * size.y + j ) * size.z + k ];
+    const V3f &c100 = table[(i1 * size.y + j ) * size.z + k ];
+    const V3f &c010 = table[(i  * size.y + j1) * size.z + k ];
+    const V3f &c110 = table[(i1 * size.y + j1) * size.z + k ];
+    const V3f &c001 = table[(i  * size.y + j ) * size.z + k1];
+    const V3f &c101 = table[(i1 * size.y + j ) * size.z + k1];
+    const V3f &c011 = table[(i  * size.y + j1) * size.z + k1];
+    const V3f &c111 = table[(i1 * size.y + j1) * size.z + k1];
+
+    //
+    // Sort the fractional coordinates, (u, v, w), and interpolate
+    // between the four corners of the tetrahedron that contains them:
+    // c000, c111, and the two corners reached from c000 by first
+    // stepping along the axis with the largest fraction and then
+    // along the axis with the second-largest fraction.  With the
+    // fractions sorted into hi >= mid >= lo, the corner weights are
+    // (1 - hi), (hi - mid), (mid - lo) and lo.
+    //
+
+    if (u > v)
+    {
+	if (v > w)
+	    return (1 - u) * c000 + (u - v) * c100 +
+		   (v - w) * c110 + w * c111;
+	else if (u > w)
+	    return (1 - u) * c000 + (u - w) * c100 +
+		   (w - v) * c101 + v * c111;
+	else
+	    return (1 - w) * c000 + (w - u) * c001 +
+		   (u - v) * c101 + v * c111;
+    }
+    else
+    {
+	if (w > v)
+	    return (1 - w) * c000 + (w - v) * c001 +
+		   (v - u) * c011 + u * c111;
+	else if (w > u)
+	    return (1 - v) * c000 + (v - w) * c010 +
+		   (w - u) * c011 + u * c111;
+	else
+	    return (1 - v) * c000 + (v - u) * c010 +
+		   (u - w) * c110 + w * c111;
+    }
+}
+
+
+float
 interpolate1D
     (const float table[][2],
      int size,

--- a/lib/IlmCtlMath/CtlLookupTable.h
+++ b/lib/IlmCtlMath/CtlLookupTable.h
@@ -57,8 +57,8 @@
 
 //-----------------------------------------------------------------------------
 //
-//	1D and 3D table lookups with linear, trilinear and
-//	cubic interpolation.
+//	1D and 3D table lookups with linear, trilinear, tetrahedral
+//	and cubic interpolation.
 //
 //	lookup1D(t,s,pMin,pMax,p)
 //
@@ -86,6 +86,17 @@
 //		is not known at compile time, lookup table t is passed
 //		to lookup3D as a 1D array, with table entry t[i][j][k]
 //		at location t[(i * s.y + j) * s.z + k];
+//
+//	lookup3DTetra(t,s,pMin,pMax,p)
+//
+//		Like lookup3D(t,s,pMin,pMax,p), except with tetrahedral
+//		rather than trilinear interpolation between the table
+//		entries:  each cell of the table is split into six
+//		tetrahedra around its main diagonal, and f interpolates
+//		between the four corners of the tetrahedron that
+//		contains pClamp.  Along the main diagonal of a cell,
+//		f is a linear blend of only the two diagonal corner
+//		entries.
 //
 //	interpolate1D(t,s,p)
 //
@@ -126,6 +137,12 @@ Imath::V3f	lookup3D (const Imath::V3f table[],
 			  const Imath::V3f &pMin,
 			  const Imath::V3f &pMax,
 			  const Imath::V3f &p);
+
+Imath::V3f	lookup3DTetra (const Imath::V3f table[],
+			       const Imath::V3i &size,
+			       const Imath::V3f &pMin,
+			       const Imath::V3f &pMax,
+			       const Imath::V3f &p);
 
 float		interpolate1D (const float table[][2],
 			       int size,

--- a/lib/IlmCtlSimd/CtlSimdStdLibLookupTable.cpp
+++ b/lib/IlmCtlSimd/CtlSimdStdLibLookupTable.cpp
@@ -178,13 +178,20 @@ simdLookupCubic1D (const SimdBoolMask &mask, SimdXContext &xcontext)
 }
 
 
+typedef V3f (*Lookup3DFunc) (const V3f[], const V3i &,
+			     const V3f &, const V3f &, const V3f &);
+
+
 void
-simdLookup3D_f3 (const SimdBoolMask &mask, SimdXContext &xcontext)
+simdDoLookup3D_f3
+    (const SimdBoolMask &mask,
+     SimdXContext &xcontext,
+     Lookup3DFunc func)
 {
     //
-    // float[3] lookup3D_f3 (float table[][][][3],
-    //			     float pMin[3], float pMax[3],
-    //			     float p[3])
+    // float[3] func (float table[][][][3],
+    //		      float pMin[3], float pMax[3],
+    //		      float p[3])
     //
 
     const SimdReg &size2  = xcontext.stack().regFpRelative (-1);
@@ -213,11 +220,11 @@ simdLookup3D_f3 (const SimdBoolMask &mask, SimdXContext &xcontext)
 	{
 	    if (mask[i])
 	    {
-		*(V3f *)(returnValue[i]) = lookup3D ((V3f *)(table[i]), 
-						     s,
-						     *(V3f *)(pMin[i]),
-						     *(V3f *)(pMax[i]),
-						     *(V3f *)(p[i]));
+		*(V3f *)(returnValue[i]) = func ((V3f *)(table[i]),
+						 s,
+						 *(V3f *)(pMin[i]),
+						 *(V3f *)(pMax[i]),
+						 *(V3f *)(p[i]));
 	    }
 	}
     }
@@ -225,23 +232,52 @@ simdLookup3D_f3 (const SimdBoolMask &mask, SimdXContext &xcontext)
     {
 	returnValue.setVarying (false);
 
-	*(V3f *)(returnValue[0]) = lookup3D ((V3f *)(table[0]), 
-					     s,
-					     *(V3f *)(pMin[0]),
-					     *(V3f *)(pMax[0]),
-					     *(V3f *)(p[0]));
+	*(V3f *)(returnValue[0]) = func ((V3f *)(table[0]),
+					 s,
+					 *(V3f *)(pMin[0]),
+					 *(V3f *)(pMax[0]),
+					 *(V3f *)(p[0]));
     }
 }
 
 
 void
-simdLookup3D_f (const SimdBoolMask &mask, SimdXContext &xcontext)
+simdLookup3D_f3 (const SimdBoolMask &mask, SimdXContext &xcontext)
 {
     //
-    // void lookup3D_f (float table[][][][3],
-    //		        float pMin[3], float pMax[3],
-    //		        float p0, float p1, float p2,
-    //		        float q0, float q1, float q2)
+    // float[3] lookup3D_f3 (float table[][][][3],
+    //			     float pMin[3], float pMax[3],
+    //			     float p[3])
+    //
+
+    simdDoLookup3D_f3 (mask, xcontext, lookup3D);
+}
+
+
+void
+simdLookup3DTetra_f3 (const SimdBoolMask &mask, SimdXContext &xcontext)
+{
+    //
+    // float[3] lookup3DTetra_f3 (float table[][][][3],
+    //			          float pMin[3], float pMax[3],
+    //			          float p[3])
+    //
+
+    simdDoLookup3D_f3 (mask, xcontext, lookup3DTetra);
+}
+
+
+void
+simdDoLookup3D_f
+    (const SimdBoolMask &mask,
+     SimdXContext &xcontext,
+     Lookup3DFunc func)
+{
+    //
+    // void func (float table[][][][3],
+    //		  float pMin[3], float pMax[3],
+    //		  float p0, float p1, float p2,
+    //		  float q0, float q1, float q2)
     //
 
     const SimdReg &size2  = xcontext.stack().regFpRelative (-1);
@@ -280,11 +316,11 @@ simdLookup3D_f (const SimdBoolMask &mask, SimdXContext &xcontext)
 	    {
 		V3f p (*(float *)p0[i], *(float *)p1[i], *(float *)p2[i]);
 
-		V3f q = lookup3D ((V3f *)(table[i]), 
-				  s,
-				  *(V3f *)(pMin[i]),
-				  *(V3f *)(pMax[i]),
-				  p);
+		V3f q = func ((V3f *)(table[i]),
+			      s,
+			      *(V3f *)(pMin[i]),
+			      *(V3f *)(pMax[i]),
+			      p);
 
 		*(float *)q0[i] = q[0];
 		*(float *)q1[i] = q[1];
@@ -300,11 +336,11 @@ simdLookup3D_f (const SimdBoolMask &mask, SimdXContext &xcontext)
 
 	V3f p (*(float *)p0[0], *(float *)p1[0], *(float *)p2[0]);
 
-	V3f q = lookup3D ((V3f *)(table[0]), 
-			  s,
-			  *(V3f *)(pMin[0]),
-			  *(V3f *)(pMax[0]),
-			  p);
+	V3f q = func ((V3f *)(table[0]),
+		      s,
+		      *(V3f *)(pMin[0]),
+		      *(V3f *)(pMax[0]),
+		      p);
 
 	*(float *)q0[0] = q[0];
 	*(float *)q1[0] = q[1];
@@ -314,13 +350,44 @@ simdLookup3D_f (const SimdBoolMask &mask, SimdXContext &xcontext)
 
 
 void
-simdLookup3D_h (const SimdBoolMask &mask, SimdXContext &xcontext)
+simdLookup3D_f (const SimdBoolMask &mask, SimdXContext &xcontext)
 {
     //
-    // void lookup3D_h (float table[][][][3],
+    // void lookup3D_f (float table[][][][3],
     //		        float pMin[3], float pMax[3],
-    //		        half p0, half p1, half p2,
-    //		        half q0, half q1, half q2)
+    //		        float p0, float p1, float p2,
+    //		        float q0, float q1, float q2)
+    //
+
+    simdDoLookup3D_f (mask, xcontext, lookup3D);
+}
+
+
+void
+simdLookup3DTetra_f (const SimdBoolMask &mask, SimdXContext &xcontext)
+{
+    //
+    // void lookup3DTetra_f (float table[][][][3],
+    //			     float pMin[3], float pMax[3],
+    //			     float p0, float p1, float p2,
+    //			     float q0, float q1, float q2)
+    //
+
+    simdDoLookup3D_f (mask, xcontext, lookup3DTetra);
+}
+
+
+void
+simdDoLookup3D_h
+    (const SimdBoolMask &mask,
+     SimdXContext &xcontext,
+     Lookup3DFunc func)
+{
+    //
+    // void func (float table[][][][3],
+    //		  float pMin[3], float pMax[3],
+    //		  half p0, half p1, half p2,
+    //		  half q0, half q1, half q2)
     //
 
     const SimdReg &size2  = xcontext.stack().regFpRelative (-1);
@@ -359,11 +426,11 @@ simdLookup3D_h (const SimdBoolMask &mask, SimdXContext &xcontext)
 	    {
 		V3f p (*(half *)p0[i], *(half *)p1[i], *(half *)p2[i]);
 
-		V3f q = lookup3D ((V3f *)(table[i]), 
-				  s,
-				  *(V3f *)(pMin[i]),
-				  *(V3f *)(pMax[i]),
-				  p);
+		V3f q = func ((V3f *)(table[i]),
+			      s,
+			      *(V3f *)(pMin[i]),
+			      *(V3f *)(pMax[i]),
+			      p);
 
 		*(half *)q0[i] = q[0];
 		*(half *)q1[i] = q[1];
@@ -379,16 +446,44 @@ simdLookup3D_h (const SimdBoolMask &mask, SimdXContext &xcontext)
 
 	V3f p (*(half *)p0[0], *(half *)p1[0], *(half *)p2[0]);
 
-	V3f q = lookup3D ((V3f *)(table[0]), 
-			  s,
-			  *(V3f *)(pMin[0]),
-			  *(V3f *)(pMax[0]),
-			  p);
+	V3f q = func ((V3f *)(table[0]),
+		      s,
+		      *(V3f *)(pMin[0]),
+		      *(V3f *)(pMax[0]),
+		      p);
 
 	*(half *)q0[0] = q[0];
 	*(half *)q1[0] = q[1];
 	*(half *)q2[0] = q[2];
     }
+}
+
+
+void
+simdLookup3D_h (const SimdBoolMask &mask, SimdXContext &xcontext)
+{
+    //
+    // void lookup3D_h (float table[][][][3],
+    //		        float pMin[3], float pMax[3],
+    //		        half p0, half p1, half p2,
+    //		        half q0, half q1, half q2)
+    //
+
+    simdDoLookup3D_h (mask, xcontext, lookup3D);
+}
+
+
+void
+simdLookup3DTetra_h (const SimdBoolMask &mask, SimdXContext &xcontext)
+{
+    //
+    // void lookup3DTetra_h (float table[][][][3],
+    //			     float pMin[3], float pMax[3],
+    //			     half p0, half p1, half p2,
+    //			     half q0, half q1, half q2)
+    //
+
+    simdDoLookup3D_h (mask, xcontext, lookup3DTetra);
 }
 
 
@@ -499,6 +594,15 @@ declareSimdStdLibLookupTable (SymbolTable &symtab, SimdStdTypes &types)
 
     declareSimdCFunc (symtab, simdLookup3D_h,
 		      types.funcType_v_f0003_f3_f3_hhh_ohhh(), "lookup3D_h");
+
+    declareSimdCFunc (symtab, simdLookup3DTetra_f3,
+		      types.funcType_f3_f0003_f3_f3_f3(), "lookup3DTetra_f3");
+
+    declareSimdCFunc (symtab, simdLookup3DTetra_f,
+		      types.funcType_v_f0003_f3_f3_fff_offf(), "lookup3DTetra_f");
+
+    declareSimdCFunc (symtab, simdLookup3DTetra_h,
+		      types.funcType_v_f0003_f3_f3_hhh_ohhh(), "lookup3DTetra_h");
 
     declareSimdCFunc (symtab, simdInterpolate1D,
 		      types.funcType_f_f02_f(), "interpolate1D");

--- a/unittest/IlmCtl/testLookupTables.ctl
+++ b/unittest/IlmCtl/testLookupTables.ctl
@@ -219,6 +219,166 @@ testLookup3D ()
 
 
 void
+testLookup3DTetra ()
+{
+    print ("Testing 3D table lookups, tetrahedral, regular spacing\n");
+
+    float f[2][2][2][3];
+
+    f[0][0][0] = f3 (2, 2, 2);
+    f[0][0][1] = f3 (2, 2, 6);
+    f[0][1][0] = f3 (2, 6, 2);
+    f[0][1][1] = f3 (2, 6, 6);
+    f[1][0][0] = f3 (6, 2, 2);
+    f[1][0][1] = f3 (6, 2, 6);
+    f[1][1][0] = f3 (6, 6, 2);
+    f[1][1][1] = f3 (6, 6, 6);
+
+    float fMin[3] = {1, 1, 1};
+    float fMax[3] = {5, 5, 5};
+
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (1, 1, 1)), f3 (2, 2, 2)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (5, 1, 1)), f3 (6, 2, 2)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (1, 5, 1)), f3 (2, 6, 2)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (5, 5, 1)), f3 (6, 6, 2)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (1, 1, 5)), f3 (2, 2, 6)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (5, 1, 5)), f3 (6, 2, 6)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (1, 5, 5)), f3 (2, 6, 6)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (5, 5, 5)), f3 (6, 6, 6)));
+
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (2, 2, 2)), f3 (3, 3, 3)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (4, 2, 2)), f3 (5, 3, 3)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (2, 4, 2)), f3 (3, 5, 3)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (4, 4, 2)), f3 (5, 5, 3)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (2, 2, 4)), f3 (3, 3, 5)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (4, 2, 4)), f3 (5, 3, 5)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (2, 4, 4)), f3 (3, 5, 5)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (4, 4, 4)), f3 (5, 5, 5)));
+
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (0, 0, 0)), f3 (2, 2, 2)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (6, 0, 0)), f3 (6, 2, 2)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (0, 6, 0)), f3 (2, 6, 2)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (6, 6, 0)), f3 (6, 6, 2)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (0, 0, 6)), f3 (2, 2, 6)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (6, 0, 6)), f3 (6, 2, 6)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (0, 6, 6)), f3 (2, 6, 6)));
+    assert (equal (lookup3DTetra_f3 (f, fMin, fMax, f3 (6, 6, 6)), f3 (6, 6, 6)));
+
+    //
+    // A table that is non-linear in (i, j, k) so tetrahedral and
+    // trilinear weightings disagree:
+    //
+    //     t[i][j][k] = {4*i + 2*j + k, i*j, j*k}
+    //
+    // Probe the six permutations of (0.25, 0.5, 0.75).  Each lands in a
+    // different tetrahedron of the same cell, and for every permutation
+    // the sorted fractions are (0.75, 0.5, 0.25), so all four blend
+    // weights are exactly 0.25 and each expected value is exact in
+    // float arithmetic.
+    //
+
+    float t[2][2][2][3];
+
+    for (int i = 0; i < 2; i = i + 1)
+	for (int j = 0; j < 2; j = j + 1)
+	    for (int k = 0; k < 2; k = k + 1)
+		t[i][j][k] = f3 (4 * i + 2 * j + k, i * j, j * k);
+
+    float tMin[3] = {0, 0, 0};
+    float tMax[3] = {1, 1, 1};
+
+    assert (equal (lookup3DTetra_f3 (t, tMin, tMax, f3 (.75, .50, .25)),
+		   f3 (4.25, 0.50, 0.25)));
+    assert (equal (lookup3DTetra_f3 (t, tMin, tMax, f3 (.75, .25, .50)),
+		   f3 (4.00, 0.25, 0.25)));
+    assert (equal (lookup3DTetra_f3 (t, tMin, tMax, f3 (.50, .25, .75)),
+		   f3 (3.25, 0.25, 0.25)));
+    assert (equal (lookup3DTetra_f3 (t, tMin, tMax, f3 (.25, .50, .75)),
+		   f3 (2.75, 0.25, 0.50)));
+    assert (equal (lookup3DTetra_f3 (t, tMin, tMax, f3 (.25, .75, .50)),
+		   f3 (3.00, 0.25, 0.50)));
+    assert (equal (lookup3DTetra_f3 (t, tMin, tMax, f3 (.50, .75, .25)),
+		   f3 (3.75, 0.50, 0.25)));
+
+    //
+    // Tetrahedral and trilinear must actually differ on this table:
+    // at (.75, .50, .25) trilinear gives i*j -> u*v = 0.375, while the
+    // tetrahedral blend gives 0.5.
+    //
+
+    assert (lookup3D_f3 (t, tMin, tMax, f3 (.75, .50, .25))[1] == 0.375);
+    assert (lookup3DTetra_f3 (t, tMin, tMax, f3 (.75, .50, .25))[1] == 0.5);
+
+    float xf;
+    float yf;
+    float zf;
+
+    half xh;
+    half yh;
+    half zh;
+
+    float g[2][3][4][3];
+    float gMin[3];
+    float gMax[3];
+
+    gMin = f3 (0, 0, 0);
+    gMax = f3 (1, 2, 3);
+
+    for (int i = 0; i < 2; i = i + 1)
+	for (int j = 0; j < 3; j = j + 1)
+	    for (int k = 0; k < 4; k = k + 1)
+		g[i][j][k] = f3 (i, j, k);
+
+    assert (equal (lookup3DTetra_f3 (g, gMin, gMax, f3 (.25, 1.5, 2.75)),
+		   f3 (.25, 1.5, 2.75)));
+
+    lookup3DTetra_f (g, gMin, gMax, .25, 1.5, 2.75, xf, yf, zf);
+    assert (xf == .25 && yf == 1.5 && zf == 2.75);
+
+    lookup3DTetra_h (g, gMin, gMax, .25, 1.5, 2.75, xh, yh, zh);
+    assert (xh == .25 && yh == 1.5 && zh == 2.75);
+
+    for (int i = 0; i < 2; i = i + 1)
+	for (int j = 0; j < 3; j = j + 1)
+	    for (int k = 0; k < 4; k = k + 1)
+	    {
+		assert (equal (lookup3DTetra_f3 (g, gMin, gMax, f3 (i, j, k)),
+			       f3 (i, j, k)));
+
+		lookup3DTetra_f (g, gMin, gMax, i, j, k, xf, yf, zf);
+		assert (xf == i && yf == j && zf == k);
+
+		lookup3DTetra_h (g, gMin, gMax, i, j, k, xh, yh, zh);
+		assert (xh == i && yh == j && zh == k);
+	    }
+
+    gMin = f3 (2, 4, 6);
+    gMax = f3 (3, 6, 9);
+    int n = 0;
+
+    for (int i = 0; i < 2; i = i + 1)
+	for (int j = 0; j < 3; j = j + 1)
+	    for (int k = 0; k < 4; k = k + 1)
+	    {
+		assert (equal (lookup3DTetra_f3 (g, gMin, gMax,
+						 f3 (i+2, j+4, k+6)),
+			       f3 (i, j, k)));
+
+		lookup3DTetra_f (g, gMin, gMax, i+2, j+4, k+6, xf, yf, zf);
+		assert (xf == i && yf == j && zf == k);
+
+		lookup3DTetra_h (g, gMin, gMax, i+2, j+4, k+6, xh, yh, zh);
+		assert (xh == i && yh == j && zh == k);
+
+		n = n + 1;
+	    }
+
+    assert (n == 2 * 3 * 4);
+    print ("ok\n");
+}
+
+
+void
 testInterpolate1D ()
 {
     print ("Testing 1D table lookups: linear, random spacing\n");
@@ -302,6 +462,7 @@ testLookupTables ()
     testLookup1D();
     testLookupCubic1D();
     testLookup3D();
+    testLookup3DTetra();
     testInterpolate1D();
     testInterpolateCubic1D();
     return 0;

--- a/unittest/IlmCtl/testVaryingLookup.cpp
+++ b/unittest/IlmCtl/testVaryingLookup.cpp
@@ -61,6 +61,7 @@
 #include <exception>
 #include <assert.h>
 #include <sstream>
+#include <stdlib.h>
 
 using namespace Ctl;
 using namespace std;
@@ -235,11 +236,9 @@ testLookupCubic1D (Interpreter &interp)
 
 
 void
-testLookup3D (Interpreter &interp)
+testLookup3D (Interpreter &interp, const char *functionName)
 {
-    cout << "3D, linear, regular spacing" << endl;
-
-    FunctionCallPtr func = interp.newFunctionCall ("varyingLookup3D");
+    FunctionCallPtr func = interp.newFunctionCall (functionName);
     assert (func);
 
     FunctionArgPtr pMin = func->findInputArg ("pMin");
@@ -514,6 +513,114 @@ testInterpolateCubic1D (Interpreter &interp)
 }
 
 
+//
+// Release builds define NDEBUG, which turns assert() into nothing, so a
+// check written with assert() reports success whatever it observed.
+//
+#define TETRA_REQUIRE(x)                                                \
+    do {                                                                \
+        if (!(x)) {                                                     \
+            std::cerr << "REQUIRE failed: " #x " at " << __FILE__       \
+                      << ":" << __LINE__ << std::endl;                  \
+            exit (1);                                                   \
+        }                                                               \
+    } while (0)
+
+
+//
+// lookup3DTetra splits each cell into six tetrahedra and picks one by
+// ordering the fractional coordinates.  Probe all six.
+//
+// The shared testLookup3D above cannot do this.  Its probes land exactly
+// on grid corners, so every fractional coordinate is zero and only the
+// degenerate case is ever reached, and its table is linear along each
+// axis, which all six tetrahedra reproduce identically.  Both have to be
+// fixed at once for the selection to be observable at all.
+//
+static void
+testLookup3DTetraBranches (Interpreter &interp)
+{
+    cout << "3D, tetrahedral, all six tetrahedra" << endl;
+
+    // One probe per tetrahedron, each with distinct non-zero fractions.
+    // pMin/pMax are 0 and 1 over a 2x2x2 table, so the probe coordinate
+    // is the fractional coordinate.
+    static const float probes[6][3] = {
+        {0.7f, 0.5f, 0.2f},   // u > v > w
+        {0.7f, 0.2f, 0.5f},   // u > v, u > w >= v
+        {0.5f, 0.2f, 0.7f},   // w >= u > v
+        {0.2f, 0.5f, 0.7f},   // w > v >= u
+        {0.2f, 0.7f, 0.5f},   // v >= w > u
+        {0.5f, 0.7f, 0.2f},   // v >= u >= w
+    };
+
+    // Hand-computed from the fixture's corner values and the four-term
+    // blend.  Each differs from what the other five tetrahedra would
+    // give, so a wrong selection cannot pass.
+    static const float expect[6][3] = {
+        {0.7f, 0.5f, 1.4f},
+        {0.7f, 0.2f, 1.1f},
+        {0.5f, 0.2f, 1.3f},
+        {0.2f, 0.5f, 1.0f},
+        {0.2f, 0.7f, 0.8f},
+        {0.5f, 0.7f, 1.4f},
+    };
+
+    FunctionCallPtr func =
+        interp.newFunctionCall ("varyingLookup3DTetraBranches");
+    TETRA_REQUIRE (func);
+
+    FunctionArgPtr pMin = func->findInputArg ("pMin");
+    FunctionArgPtr pMax = func->findInputArg ("pMax");
+    FunctionArgPtr p    = func->findInputArg ("p");
+    FunctionArgPtr q    = func->findOutputArg ("q");
+    TETRA_REQUIRE (pMin && pMax && p && q);
+
+    char  *pMinData = pMin->data();
+    size_t pMinSize = pMin->type()->alignedObjectSize();
+    size_t pMinE    = pMin->type().cast<ArrayType>()->elementSize();
+    char  *pMaxData = pMax->data();
+    size_t pMaxSize = pMax->type()->alignedObjectSize();
+    size_t pMaxE    = pMax->type().cast<ArrayType>()->elementSize();
+    char  *pData    = p->data();
+    size_t pSize    = p->type()->alignedObjectSize();
+    size_t pE       = p->type().cast<ArrayType>()->elementSize();
+
+    for (size_t m = 0; m < 6; ++m)
+    {
+        for (size_t t = 0; t < 3; ++t)
+        {
+            *(float *)(pMinData + pMinSize * m + pMinE * t) = 0.0f;
+            *(float *)(pMaxData + pMaxSize * m + pMaxE * t) = 1.0f;
+            *(float *)(pData    + pSize    * m + pE    * t) = probes[m][t];
+        }
+    }
+
+    func->callFunction (6);
+
+    char  *qData = q->data();
+    size_t qSize = q->type()->alignedObjectSize();
+    size_t qE    = q->type().cast<ArrayType>()->elementSize();
+
+    for (size_t m = 0; m < 6; ++m)
+    {
+        for (size_t t = 0; t < 3; ++t)
+        {
+            const float got = *(float *)(qData + qSize * m + qE * t);
+            const float err = got > expect[m][t]
+                            ? got - expect[m][t] : expect[m][t] - got;
+            if (err > 1e-5f)
+            {
+                std::cerr << "tetrahedron " << (m + 1) << ", component "
+                          << t << ": expected " << expect[m][t]
+                          << ", got " << got << std::endl;
+            }
+            TETRA_REQUIRE (err <= 1e-5f);
+        }
+    }
+}
+
+
 void
 testVaryingLookup ()
 {
@@ -526,7 +633,15 @@ testVaryingLookup ()
 
 	testLookup1D (interp);
 	testLookupCubic1D (interp);
-	testLookup3D (interp);
+
+	cout << "3D, linear, regular spacing" << endl;
+	testLookup3D (interp, "varyingLookup3D");
+
+	cout << "3D, tetrahedral, regular spacing" << endl;
+	testLookup3D (interp, "varyingLookup3DTetra");
+
+	testLookup3DTetraBranches (interp);
+
 	testInterpolate1D (interp);
 	testInterpolateCubic1D (interp);
 

--- a/unittest/IlmCtl/testVaryingLookup.ctl
+++ b/unittest/IlmCtl/testVaryingLookup.ctl
@@ -67,6 +67,46 @@ varyingLookup3D
 
 
 void
+varyingLookup3DTetra
+    (input varying float pMin[3],
+     input varying float pMax[3],
+     input varying float p1[3],
+     output varying float q1[3],
+     input varying float p20,
+     input varying float p21,
+     input varying float p22,
+     output varying float q20,
+     output varying float q21,
+     output varying float q22,
+     input varying half p30,
+     input varying half p31,
+     input varying half p32,
+     output varying half q30,
+     output varying half q31,
+     output varying half q32)
+{
+    float g[2][3][4][3];
+
+    for (int i = 0; i < 2; i = i + 1)
+    {
+	for (int j = 0; j < 3; j = j + 1)
+	{
+	    for (int k = 0; k < 4; k = k + 1)
+	    {
+		g[i][j][k][0] = i;
+		g[i][j][k][1] = j;
+		g[i][j][k][2] = k;
+	    }
+	}
+    }
+
+    q1 = lookup3DTetra_f3 (g, pMin, pMax, p1);
+    lookup3DTetra_f (g, pMin, pMax, p20, p21, p22, q20, q21, q22);
+    lookup3DTetra_h (g, pMin, pMax, p30, p31, p32, q30, q31, q32);
+}
+
+
+void
 varyingInterpolate1D
     (input varying float p,
      output varying float q)
@@ -83,4 +123,34 @@ varyingInterpolateCubic1D
 {
     float h[][2] = {{1, 3}, {3, 5}};
     q = interpolateCubic1D (h, p);
+}
+
+
+//
+// Fixture for the tetrahedron-selection coverage test.
+//
+// The table is deliberately non-planar.  A table that is linear along
+// each axis is reproduced exactly by all six tetrahedra, so it cannot
+// tell a correct tetrahedron choice from a wrong one; only the corners
+// that sit off the trilinear plane make the six cases distinguishable.
+//
+void
+varyingLookup3DTetraBranches
+    (input varying float pMin[3],
+     input varying float pMax[3],
+     input varying float p[3],
+     output varying float q[3])
+{
+    float g[2][2][2][3];
+
+    g[0][0][0][0] = 0; g[0][0][0][1] = 0; g[0][0][0][2] = 0;
+    g[1][0][0][0] = 1; g[1][0][0][1] = 0; g[1][0][0][2] = 0;
+    g[0][1][0][0] = 0; g[0][1][0][1] = 1; g[0][1][0][2] = 0;
+    g[1][1][0][0] = 1; g[1][1][0][1] = 1; g[1][1][0][2] = 4;
+    g[0][0][1][0] = 0; g[0][0][1][1] = 0; g[0][0][1][2] = 1;
+    g[1][0][1][0] = 1; g[1][0][1][1] = 0; g[1][0][1][2] = 3;
+    g[0][1][1][0] = 0; g[0][1][1][1] = 1; g[0][1][1][2] = 2;
+    g[1][1][1][0] = 1; g[1][1][1][1] = 1; g[1][1][1][2] = 1;
+
+    q = lookup3DTetra_f3 (g, pMin, pMax, p);
 }


### PR DESCRIPTION
`lookup3DTetra` splits each cell into six tetrahedra and blends the four corners of the one holding the sample point. The existing `lookup3D` blends all eight corners of the cell. Most LUT formats assume tetrahedral interpolation.

Available from CTL as `lookup3DTetra_f3`, `lookup3DTetra_f` and `lookup3DTetra_h`, matching the existing `lookup3D` set.

Includes a test that probes all six tetrahedra.

Closes #203 

Category: new features

Test generation, code style compliance, and documentation Assisted-by: Calude-4.8-Opus